### PR TITLE
Add SQL Server estate inventory management application

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,183 @@
+-- ============================================================
+-- SQL Server Estate Inventory Database Schema
+-- ============================================================
+
+USE master;
+GO
+
+-- Create database if it doesn't exist
+IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = 'SQLInventory')
+BEGIN
+    CREATE DATABASE SQLInventory;
+END
+GO
+
+USE SQLInventory;
+GO
+
+-- ============================================================
+-- Environments
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Environments')
+BEGIN
+    CREATE TABLE dbo.Environments (
+        EnvironmentId INT IDENTITY(1,1) NOT NULL,
+        Name          NVARCHAR(100)     NOT NULL,
+        ColorHex      NVARCHAR(7)       NOT NULL CONSTRAINT DF_Environments_ColorHex DEFAULT '#6c757d',
+        CONSTRAINT PK_Environments PRIMARY KEY (EnvironmentId),
+        CONSTRAINT UQ_Environments_Name UNIQUE (Name)
+    );
+END
+GO
+
+-- ============================================================
+-- Tags
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Tags')
+BEGIN
+    CREATE TABLE dbo.Tags (
+        TagId    INT IDENTITY(1,1) NOT NULL,
+        Name     NVARCHAR(100)     NOT NULL,
+        ColorHex NVARCHAR(7)       NOT NULL CONSTRAINT DF_Tags_ColorHex DEFAULT '#0d6efd',
+        CONSTRAINT PK_Tags PRIMARY KEY (TagId),
+        CONSTRAINT UQ_Tags_Name UNIQUE (Name)
+    );
+END
+GO
+
+-- ============================================================
+-- SqlInstances
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'SqlInstances')
+BEGIN
+    CREATE TABLE dbo.SqlInstances (
+        InstanceId            INT IDENTITY(1,1) NOT NULL,
+        ServerName            NVARCHAR(255)     NOT NULL,
+        InstanceName          NVARCHAR(128)     NULL,       -- NULL = default instance
+        Port                  INT               NOT NULL CONSTRAINT DF_SqlInstances_Port DEFAULT 1433,
+        EnvironmentId         INT               NOT NULL,
+        SqlVersion            NVARCHAR(50)      NULL,       -- e.g. '2019', '2022'
+        SqlEdition            NVARCHAR(100)     NULL,       -- e.g. 'Enterprise', 'Standard'
+        SqlBuild              NVARCHAR(50)      NULL,       -- full build e.g. '15.0.4355.3'
+        HostOperatingSystem   NVARCHAR(255)     NULL,
+        IsClustered           BIT               NOT NULL CONSTRAINT DF_SqlInstances_IsClustered DEFAULT 0,
+        IsAlwaysOnEnabled     BIT               NOT NULL CONSTRAINT DF_SqlInstances_IsAlwaysOnEnabled DEFAULT 0,
+        MaxMemoryMb           INT               NULL,
+        CpuCount              INT               NULL,
+        ServiceAccount        NVARCHAR(255)     NULL,
+        Notes                 NVARCHAR(MAX)     NULL,
+        IsActive              BIT               NOT NULL CONSTRAINT DF_SqlInstances_IsActive DEFAULT 1,
+        LastDiscoveredUtc     DATETIME2         NULL,
+        CreatedUtc            DATETIME2         NOT NULL CONSTRAINT DF_SqlInstances_CreatedUtc DEFAULT SYSUTCDATETIME(),
+        ModifiedUtc           DATETIME2         NOT NULL CONSTRAINT DF_SqlInstances_ModifiedUtc DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT PK_SqlInstances PRIMARY KEY (InstanceId),
+        CONSTRAINT FK_SqlInstances_Environments FOREIGN KEY (EnvironmentId) REFERENCES dbo.Environments (EnvironmentId),
+        CONSTRAINT UQ_SqlInstances_ServerInstance UNIQUE (ServerName, InstanceName)
+    );
+END
+GO
+
+-- ============================================================
+-- InstanceTags  (many-to-many)
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'InstanceTags')
+BEGIN
+    CREATE TABLE dbo.InstanceTags (
+        InstanceId INT NOT NULL,
+        TagId      INT NOT NULL,
+        CONSTRAINT PK_InstanceTags PRIMARY KEY (InstanceId, TagId),
+        CONSTRAINT FK_InstanceTags_Instances FOREIGN KEY (InstanceId) REFERENCES dbo.SqlInstances (InstanceId) ON DELETE CASCADE,
+        CONSTRAINT FK_InstanceTags_Tags      FOREIGN KEY (TagId)      REFERENCES dbo.Tags (TagId)             ON DELETE CASCADE
+    );
+END
+GO
+
+-- ============================================================
+-- SqlDatabases
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'SqlDatabases')
+BEGIN
+    CREATE TABLE dbo.SqlDatabases (
+        DatabaseId          INT IDENTITY(1,1) NOT NULL,
+        InstanceId          INT               NOT NULL,
+        DatabaseName        NVARCHAR(128)     NOT NULL,
+        SizeMb              DECIMAL(18,2)     NULL,
+        CompatibilityLevel  INT               NULL,         -- e.g. 150 = SQL 2019
+        RecoveryModel       NVARCHAR(20)      NULL,         -- FULL, SIMPLE, BULK_LOGGED
+        StateDesc           NVARCHAR(60)      NULL,         -- ONLINE, OFFLINE, etc.
+        IsReadOnly          BIT               NOT NULL CONSTRAINT DF_SqlDatabases_IsReadOnly DEFAULT 0,
+        [Owner]             NVARCHAR(128)     NULL,
+        CollationName       NVARCHAR(128)     NULL,
+        LastFullBackupUtc   DATETIME2         NULL,
+        LastLogBackupUtc    DATETIME2         NULL,
+        CreatedUtc          DATETIME2         NOT NULL CONSTRAINT DF_SqlDatabases_CreatedUtc DEFAULT SYSUTCDATETIME(),
+        ModifiedUtc         DATETIME2         NOT NULL CONSTRAINT DF_SqlDatabases_ModifiedUtc DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT PK_SqlDatabases PRIMARY KEY (DatabaseId),
+        CONSTRAINT FK_SqlDatabases_Instances FOREIGN KEY (InstanceId) REFERENCES dbo.SqlInstances (InstanceId) ON DELETE CASCADE,
+        CONSTRAINT UQ_SqlDatabases_InstanceDatabase UNIQUE (InstanceId, DatabaseName)
+    );
+END
+GO
+
+-- ============================================================
+-- AvailabilityGroups
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'AvailabilityGroups')
+BEGIN
+    CREATE TABLE dbo.AvailabilityGroups (
+        AgId                       INT IDENTITY(1,1) NOT NULL,
+        PrimaryInstanceId          INT               NOT NULL,
+        AgName                     NVARCHAR(128)     NOT NULL,
+        ClusterType                NVARCHAR(50)      NULL,   -- WSFC, NONE, EXTERNAL
+        AutomatedBackupPreference  NVARCHAR(50)      NULL,
+        Notes                      NVARCHAR(MAX)     NULL,
+        CreatedUtc                 DATETIME2         NOT NULL CONSTRAINT DF_AvailabilityGroups_CreatedUtc DEFAULT SYSUTCDATETIME(),
+        ModifiedUtc                DATETIME2         NOT NULL CONSTRAINT DF_AvailabilityGroups_ModifiedUtc DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT PK_AvailabilityGroups PRIMARY KEY (AgId),
+        CONSTRAINT FK_AvailabilityGroups_PrimaryInstance FOREIGN KEY (PrimaryInstanceId) REFERENCES dbo.SqlInstances (InstanceId)
+    );
+END
+GO
+
+-- ============================================================
+-- AgReplicas
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'AgReplicas')
+BEGIN
+    CREATE TABLE dbo.AgReplicas (
+        ReplicaId        INT IDENTITY(1,1) NOT NULL,
+        AgId             INT               NOT NULL,
+        InstanceId       INT               NOT NULL,
+        Role             NVARCHAR(20)      NOT NULL,   -- PRIMARY, SECONDARY
+        AvailabilityMode NVARCHAR(30)      NULL,       -- SYNCHRONOUS_COMMIT, ASYNCHRONOUS_COMMIT
+        FailoverMode     NVARCHAR(20)      NULL,       -- AUTOMATIC, MANUAL
+        SeedingMode      NVARCHAR(20)      NULL,       -- AUTOMATIC, MANUAL
+        CONSTRAINT PK_AgReplicas PRIMARY KEY (ReplicaId),
+        CONSTRAINT FK_AgReplicas_AG       FOREIGN KEY (AgId)       REFERENCES dbo.AvailabilityGroups (AgId)    ON DELETE CASCADE,
+        CONSTRAINT FK_AgReplicas_Instance FOREIGN KEY (InstanceId) REFERENCES dbo.SqlInstances (InstanceId),
+        CONSTRAINT UQ_AgReplicas_AgInstance UNIQUE (AgId, InstanceId)
+    );
+END
+GO
+
+-- ============================================================
+-- Indexes
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_SqlInstances_EnvironmentId')
+    CREATE NONCLUSTERED INDEX IX_SqlInstances_EnvironmentId ON dbo.SqlInstances (EnvironmentId);
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_SqlDatabases_InstanceId')
+    CREATE NONCLUSTERED INDEX IX_SqlDatabases_InstanceId ON dbo.SqlDatabases (InstanceId);
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_AgReplicas_AgId')
+    CREATE NONCLUSTERED INDEX IX_AgReplicas_AgId ON dbo.AgReplicas (AgId);
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_AgReplicas_InstanceId')
+    CREATE NONCLUSTERED INDEX IX_AgReplicas_InstanceId ON dbo.AgReplicas (InstanceId);
+GO
+
+PRINT 'Schema created successfully.';
+GO

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,0 +1,128 @@
+-- ============================================================
+-- SQL Server Estate Inventory - Seed Data
+-- ============================================================
+
+USE SQLInventory;
+GO
+
+-- ============================================================
+-- Environments
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM dbo.Environments WHERE Name = 'Production')
+    INSERT INTO dbo.Environments (Name, ColorHex) VALUES ('Production', '#dc3545');
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Environments WHERE Name = 'Development')
+    INSERT INTO dbo.Environments (Name, ColorHex) VALUES ('Development', '#198754');
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Environments WHERE Name = 'Test')
+    INSERT INTO dbo.Environments (Name, ColorHex) VALUES ('Test', '#0dcaf0');
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Environments WHERE Name = 'Staging')
+    INSERT INTO dbo.Environments (Name, ColorHex) VALUES ('Staging', '#fd7e14');
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Environments WHERE Name = 'DR')
+    INSERT INTO dbo.Environments (Name, ColorHex) VALUES ('DR', '#6f42c1');
+GO
+
+-- ============================================================
+-- Sample Tags
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM dbo.Tags WHERE Name = 'Critical')
+    INSERT INTO dbo.Tags (Name, ColorHex) VALUES ('Critical', '#dc3545');
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Tags WHERE Name = 'ERP')
+    INSERT INTO dbo.Tags (Name, ColorHex) VALUES ('ERP', '#0d6efd');
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Tags WHERE Name = 'Reporting')
+    INSERT INTO dbo.Tags (Name, ColorHex) VALUES ('Reporting', '#6f42c1');
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Tags WHERE Name = 'Legacy')
+    INSERT INTO dbo.Tags (Name, ColorHex) VALUES ('Legacy', '#adb5bd');
+GO
+
+-- ============================================================
+-- Sample SQL Instances
+-- ============================================================
+DECLARE @ProdEnvId INT = (SELECT EnvironmentId FROM dbo.Environments WHERE Name = 'Production');
+DECLARE @DevEnvId  INT = (SELECT EnvironmentId FROM dbo.Environments WHERE Name = 'Development');
+
+IF NOT EXISTS (SELECT 1 FROM dbo.SqlInstances WHERE ServerName = 'SQL-PROD-01' AND InstanceName IS NULL)
+BEGIN
+    INSERT INTO dbo.SqlInstances
+        (ServerName, InstanceName, Port, EnvironmentId, SqlVersion, SqlEdition, SqlBuild,
+         HostOperatingSystem, IsClustered, IsAlwaysOnEnabled, MaxMemoryMb, CpuCount,
+         ServiceAccount, Notes, IsActive)
+    VALUES
+        ('SQL-PROD-01', NULL, 1433, @ProdEnvId, '2022', 'Enterprise',
+         '16.0.1000.6', 'Windows Server 2022', 0, 1, 65536, 16,
+         'DOMAIN\svc_sql_prod', 'Primary production SQL Server node. Part of AG-PROD-01.', 1);
+END
+
+IF NOT EXISTS (SELECT 1 FROM dbo.SqlInstances WHERE ServerName = 'SQL-PROD-02' AND InstanceName IS NULL)
+BEGIN
+    INSERT INTO dbo.SqlInstances
+        (ServerName, InstanceName, Port, EnvironmentId, SqlVersion, SqlEdition, SqlBuild,
+         HostOperatingSystem, IsClustered, IsAlwaysOnEnabled, MaxMemoryMb, CpuCount,
+         ServiceAccount, Notes, IsActive)
+    VALUES
+        ('SQL-PROD-02', NULL, 1433, @ProdEnvId, '2022', 'Enterprise',
+         '16.0.1000.6', 'Windows Server 2022', 0, 1, 65536, 16,
+         'DOMAIN\svc_sql_prod', 'Secondary production SQL Server node (AG secondary).', 1);
+END
+
+IF NOT EXISTS (SELECT 1 FROM dbo.SqlInstances WHERE ServerName = 'SQL-DEV-01' AND InstanceName IS NULL)
+BEGIN
+    INSERT INTO dbo.SqlInstances
+        (ServerName, InstanceName, Port, EnvironmentId, SqlVersion, SqlEdition, SqlBuild,
+         HostOperatingSystem, IsClustered, IsAlwaysOnEnabled, MaxMemoryMb, CpuCount,
+         ServiceAccount, Notes, IsActive)
+    VALUES
+        ('SQL-DEV-01', NULL, 1433, @DevEnvId, '2019', 'Developer',
+         '15.0.4355.3', 'Windows Server 2019', 0, 0, 8192, 4,
+         'DOMAIN\svc_sql_dev', 'Shared development SQL Server.', 1);
+END
+GO
+
+-- ============================================================
+-- Sample Databases
+-- ============================================================
+DECLARE @Prod01Id INT = (SELECT InstanceId FROM dbo.SqlInstances WHERE ServerName = 'SQL-PROD-01' AND InstanceName IS NULL);
+DECLARE @DevId    INT = (SELECT InstanceId FROM dbo.SqlInstances WHERE ServerName = 'SQL-DEV-01'  AND InstanceName IS NULL);
+
+IF @Prod01Id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM dbo.SqlDatabases WHERE InstanceId = @Prod01Id AND DatabaseName = 'OrdersDB')
+    INSERT INTO dbo.SqlDatabases (InstanceId, DatabaseName, SizeMb, CompatibilityLevel, RecoveryModel, StateDesc, IsReadOnly, [Owner], CollationName)
+    VALUES (@Prod01Id, 'OrdersDB', 51200, 160, 'FULL', 'ONLINE', 0, 'sa', 'SQL_Latin1_General_CP1_CI_AS');
+
+IF @Prod01Id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM dbo.SqlDatabases WHERE InstanceId = @Prod01Id AND DatabaseName = 'CustomersDB')
+    INSERT INTO dbo.SqlDatabases (InstanceId, DatabaseName, SizeMb, CompatibilityLevel, RecoveryModel, StateDesc, IsReadOnly, [Owner], CollationName)
+    VALUES (@Prod01Id, 'CustomersDB', 20480, 160, 'FULL', 'ONLINE', 0, 'sa', 'SQL_Latin1_General_CP1_CI_AS');
+
+IF @DevId IS NOT NULL AND NOT EXISTS (SELECT 1 FROM dbo.SqlDatabases WHERE InstanceId = @DevId AND DatabaseName = 'OrdersDB_Dev')
+    INSERT INTO dbo.SqlDatabases (InstanceId, DatabaseName, SizeMb, CompatibilityLevel, RecoveryModel, StateDesc, IsReadOnly, [Owner], CollationName)
+    VALUES (@DevId, 'OrdersDB_Dev', 1024, 150, 'SIMPLE', 'ONLINE', 0, 'sa', 'SQL_Latin1_General_CP1_CI_AS');
+GO
+
+-- ============================================================
+-- Sample Availability Group
+-- ============================================================
+DECLARE @Prod01Id INT = (SELECT InstanceId FROM dbo.SqlInstances WHERE ServerName = 'SQL-PROD-01' AND InstanceName IS NULL);
+DECLARE @Prod02Id INT = (SELECT InstanceId FROM dbo.SqlInstances WHERE ServerName = 'SQL-PROD-02' AND InstanceName IS NULL);
+
+IF @Prod01Id IS NOT NULL AND @Prod02Id IS NOT NULL
+   AND NOT EXISTS (SELECT 1 FROM dbo.AvailabilityGroups WHERE AgName = 'AG-PROD-01')
+BEGIN
+    INSERT INTO dbo.AvailabilityGroups (PrimaryInstanceId, AgName, ClusterType, AutomatedBackupPreference, Notes)
+    VALUES (@Prod01Id, 'AG-PROD-01', 'WSFC', 'SECONDARY', 'Primary production availability group');
+
+    DECLARE @AgId INT = SCOPE_IDENTITY();
+
+    INSERT INTO dbo.AgReplicas (AgId, InstanceId, Role, AvailabilityMode, FailoverMode, SeedingMode)
+    VALUES (@AgId, @Prod01Id, 'PRIMARY',   'SYNCHRONOUS_COMMIT',  'AUTOMATIC', 'AUTOMATIC');
+
+    INSERT INTO dbo.AgReplicas (AgId, InstanceId, Role, AvailabilityMode, FailoverMode, SeedingMode)
+    VALUES (@AgId, @Prod02Id, 'SECONDARY', 'SYNCHRONOUS_COMMIT',  'AUTOMATIC', 'AUTOMATIC');
+END
+GO
+
+PRINT 'Seed data inserted successfully.';
+GO

--- a/src/SQLInventory/Components/App.razor
+++ b/src/SQLInventory/Components/App.razor
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="~/" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+    <link rel="stylesheet" href="css/site.css" />
+    <HeadOutlet @rendermode="InteractiveServer" />
+</head>
+
+<body>
+    <Routes @rendermode="InteractiveServer" />
+    <script src="_framework/blazor.server.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+
+</html>

--- a/src/SQLInventory/Components/Layout/MainLayout.razor
+++ b/src/SQLInventory/Components/Layout/MainLayout.razor
@@ -1,0 +1,10 @@
+@inherits LayoutComponentBase
+
+<div class="app-shell">
+    <NavMenu />
+    <main class="main-content">
+        <div class="container-fluid py-3">
+            @Body
+        </div>
+    </main>
+</div>

--- a/src/SQLInventory/Components/Layout/MainLayout.razor.css
+++ b/src/SQLInventory/Components/Layout/MainLayout.razor.css
@@ -1,0 +1,24 @@
+.app-shell {
+    display: flex;
+    height: 100vh;
+    overflow: hidden;
+}
+
+.sidebar {
+    width: 240px;
+    min-height: 100vh;
+    background-color: #212529;
+    flex-shrink: 0;
+    overflow-y: auto;
+}
+
+.sidebar .nav-link:hover,
+.sidebar .nav-link.active {
+    background-color: rgba(255, 255, 255, 0.15);
+}
+
+.main-content {
+    flex: 1;
+    overflow-y: auto;
+    background-color: #f8f9fa;
+}

--- a/src/SQLInventory/Components/Layout/NavMenu.razor
+++ b/src/SQLInventory/Components/Layout/NavMenu.razor
@@ -1,0 +1,40 @@
+<nav class="sidebar d-flex flex-column flex-shrink-0 p-3 text-white">
+    <a href="/" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-white text-decoration-none">
+        <i class="bi bi-server me-2 fs-4"></i>
+        <span class="fs-5 fw-semibold">SQL Inventory</span>
+    </a>
+    <hr />
+    <ul class="nav nav-pills flex-column mb-auto">
+        <li class="nav-item">
+            <NavLink class="nav-link text-white" href="" Match="NavLinkMatch.All">
+                <i class="bi bi-speedometer2 me-2"></i>Dashboard
+            </NavLink>
+        </li>
+        <li class="nav-item">
+            <NavLink class="nav-link text-white" href="instances">
+                <i class="bi bi-server me-2"></i>Instances
+            </NavLink>
+        </li>
+        <li class="nav-item">
+            <NavLink class="nav-link text-white" href="databases">
+                <i class="bi bi-database me-2"></i>Databases
+            </NavLink>
+        </li>
+        <li class="nav-item">
+            <NavLink class="nav-link text-white" href="availability-groups">
+                <i class="bi bi-diagram-3 me-2"></i>Availability Groups
+            </NavLink>
+        </li>
+        <li class="nav-item">
+            <NavLink class="nav-link text-white" href="tags">
+                <i class="bi bi-tags me-2"></i>Tags
+            </NavLink>
+        </li>
+        <hr />
+        <li class="nav-item">
+            <NavLink class="nav-link text-white" href="discovery">
+                <i class="bi bi-search me-2"></i>Discovery
+            </NavLink>
+        </li>
+    </ul>
+</nav>

--- a/src/SQLInventory/Components/Routes.razor
+++ b/src/SQLInventory/Components/Routes.razor
@@ -1,0 +1,12 @@
+<Router AppAssembly="typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(SQLInventory.Components.Layout.MainLayout)" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+    <NotFound>
+        <PageTitle>Not found</PageTitle>
+        <LayoutView Layout="typeof(SQLInventory.Components.Layout.MainLayout)">
+            <p role="alert">Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/src/SQLInventory/Data/AppDbContext.cs
+++ b/src/SQLInventory/Data/AppDbContext.cs
@@ -1,0 +1,142 @@
+using Microsoft.EntityFrameworkCore;
+using SQLInventory.Data.Entities;
+using Environment = SQLInventory.Data.Entities.Environment;
+
+namespace SQLInventory.Data;
+
+public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+    public DbSet<Environment> Environments => Set<Environment>();
+    public DbSet<Tag> Tags => Set<Tag>();
+    public DbSet<SqlInstance> SqlInstances => Set<SqlInstance>();
+    public DbSet<InstanceTag> InstanceTags => Set<InstanceTag>();
+    public DbSet<SqlDatabase> SqlDatabases => Set<SqlDatabase>();
+    public DbSet<AvailabilityGroup> AvailabilityGroups => Set<AvailabilityGroup>();
+    public DbSet<AgReplica> AgReplicas => Set<AgReplica>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // Environment
+        modelBuilder.Entity<Environment>(e =>
+        {
+            e.ToTable("Environments");
+            e.HasKey(x => x.EnvironmentId);
+            e.Property(x => x.Name).HasMaxLength(100).IsRequired();
+            e.Property(x => x.ColorHex).HasMaxLength(7).HasDefaultValue("#6c757d");
+            e.HasIndex(x => x.Name).IsUnique();
+        });
+
+        // Tag
+        modelBuilder.Entity<Tag>(e =>
+        {
+            e.ToTable("Tags");
+            e.HasKey(x => x.TagId);
+            e.Property(x => x.Name).HasMaxLength(100).IsRequired();
+            e.Property(x => x.ColorHex).HasMaxLength(7).HasDefaultValue("#0d6efd");
+            e.HasIndex(x => x.Name).IsUnique();
+        });
+
+        // SqlInstance
+        modelBuilder.Entity<SqlInstance>(e =>
+        {
+            e.ToTable("SqlInstances");
+            e.HasKey(x => x.InstanceId);
+            e.Property(x => x.ServerName).HasMaxLength(255).IsRequired();
+            e.Property(x => x.InstanceName).HasMaxLength(128);
+            e.Property(x => x.Port).HasDefaultValue(1433);
+            e.Property(x => x.SqlVersion).HasMaxLength(50);
+            e.Property(x => x.SqlEdition).HasMaxLength(100);
+            e.Property(x => x.SqlBuild).HasMaxLength(50);
+            e.Property(x => x.HostOperatingSystem).HasMaxLength(255);
+            e.Property(x => x.ServiceAccount).HasMaxLength(255);
+            e.Property(x => x.IsActive).HasDefaultValue(true);
+            e.Property(x => x.CreatedUtc).HasDefaultValueSql("SYSUTCDATETIME()");
+            e.Property(x => x.ModifiedUtc).HasDefaultValueSql("SYSUTCDATETIME()");
+            e.HasIndex(x => new { x.ServerName, x.InstanceName }).IsUnique();
+            e.Ignore(x => x.FullName);
+            e.Ignore(x => x.ConnectionName);
+
+            e.HasOne(x => x.Environment)
+             .WithMany(x => x.Instances)
+             .HasForeignKey(x => x.EnvironmentId);
+        });
+
+        // InstanceTag (many-to-many join)
+        modelBuilder.Entity<InstanceTag>(e =>
+        {
+            e.ToTable("InstanceTags");
+            e.HasKey(x => new { x.InstanceId, x.TagId });
+
+            e.HasOne(x => x.Instance)
+             .WithMany(x => x.InstanceTags)
+             .HasForeignKey(x => x.InstanceId)
+             .OnDelete(DeleteBehavior.Cascade);
+
+            e.HasOne(x => x.Tag)
+             .WithMany(x => x.InstanceTags)
+             .HasForeignKey(x => x.TagId)
+             .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // SqlDatabase
+        modelBuilder.Entity<SqlDatabase>(e =>
+        {
+            e.ToTable("SqlDatabases");
+            e.HasKey(x => x.DatabaseId);
+            e.Property(x => x.DatabaseName).HasMaxLength(128).IsRequired();
+            e.Property(x => x.SizeMb).HasColumnType("decimal(18,2)");
+            e.Property(x => x.RecoveryModel).HasMaxLength(20);
+            e.Property(x => x.StateDesc).HasMaxLength(60);
+            e.Property(x => x.Owner).HasMaxLength(128);
+            e.Property(x => x.CollationName).HasMaxLength(128);
+            e.Property(x => x.CreatedUtc).HasDefaultValueSql("SYSUTCDATETIME()");
+            e.Property(x => x.ModifiedUtc).HasDefaultValueSql("SYSUTCDATETIME()");
+            e.HasIndex(x => new { x.InstanceId, x.DatabaseName }).IsUnique();
+            e.Ignore(x => x.SizeGb);
+
+            e.HasOne(x => x.Instance)
+             .WithMany(x => x.Databases)
+             .HasForeignKey(x => x.InstanceId)
+             .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // AvailabilityGroup
+        modelBuilder.Entity<AvailabilityGroup>(e =>
+        {
+            e.ToTable("AvailabilityGroups");
+            e.HasKey(x => x.AgId);
+            e.Property(x => x.AgName).HasMaxLength(128).IsRequired();
+            e.Property(x => x.ClusterType).HasMaxLength(50);
+            e.Property(x => x.AutomatedBackupPreference).HasMaxLength(50);
+            e.Property(x => x.CreatedUtc).HasDefaultValueSql("SYSUTCDATETIME()");
+            e.Property(x => x.ModifiedUtc).HasDefaultValueSql("SYSUTCDATETIME()");
+
+            e.HasOne(x => x.PrimaryInstance)
+             .WithMany(x => x.PrimaryAvailabilityGroups)
+             .HasForeignKey(x => x.PrimaryInstanceId)
+             .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        // AgReplica
+        modelBuilder.Entity<AgReplica>(e =>
+        {
+            e.ToTable("AgReplicas");
+            e.HasKey(x => x.ReplicaId);
+            e.Property(x => x.Role).HasMaxLength(20).IsRequired();
+            e.Property(x => x.AvailabilityMode).HasMaxLength(30);
+            e.Property(x => x.FailoverMode).HasMaxLength(20);
+            e.Property(x => x.SeedingMode).HasMaxLength(20);
+            e.HasIndex(x => new { x.AgId, x.InstanceId }).IsUnique();
+
+            e.HasOne(x => x.AvailabilityGroup)
+             .WithMany(x => x.Replicas)
+             .HasForeignKey(x => x.AgId)
+             .OnDelete(DeleteBehavior.Cascade);
+
+            e.HasOne(x => x.Instance)
+             .WithMany(x => x.AgReplicas)
+             .HasForeignKey(x => x.InstanceId)
+             .OnDelete(DeleteBehavior.Restrict);
+        });
+    }
+}

--- a/src/SQLInventory/Data/Entities/AgReplica.cs
+++ b/src/SQLInventory/Data/Entities/AgReplica.cs
@@ -1,0 +1,15 @@
+namespace SQLInventory.Data.Entities;
+
+public class AgReplica
+{
+    public int ReplicaId { get; set; }
+    public int AgId { get; set; }
+    public int InstanceId { get; set; }
+    public string Role { get; set; } = "";
+    public string? AvailabilityMode { get; set; }
+    public string? FailoverMode { get; set; }
+    public string? SeedingMode { get; set; }
+
+    public AvailabilityGroup AvailabilityGroup { get; set; } = null!;
+    public SqlInstance Instance { get; set; } = null!;
+}

--- a/src/SQLInventory/Data/Entities/AvailabilityGroup.cs
+++ b/src/SQLInventory/Data/Entities/AvailabilityGroup.cs
@@ -1,0 +1,16 @@
+namespace SQLInventory.Data.Entities;
+
+public class AvailabilityGroup
+{
+    public int AgId { get; set; }
+    public int PrimaryInstanceId { get; set; }
+    public string AgName { get; set; } = "";
+    public string? ClusterType { get; set; }
+    public string? AutomatedBackupPreference { get; set; }
+    public string? Notes { get; set; }
+    public DateTime CreatedUtc { get; set; }
+    public DateTime ModifiedUtc { get; set; }
+
+    public SqlInstance PrimaryInstance { get; set; } = null!;
+    public ICollection<AgReplica> Replicas { get; set; } = [];
+}

--- a/src/SQLInventory/Data/Entities/Environment.cs
+++ b/src/SQLInventory/Data/Entities/Environment.cs
@@ -1,0 +1,10 @@
+namespace SQLInventory.Data.Entities;
+
+public class Environment
+{
+    public int EnvironmentId { get; set; }
+    public string Name { get; set; } = "";
+    public string ColorHex { get; set; } = "#6c757d";
+
+    public ICollection<SqlInstance> Instances { get; set; } = [];
+}

--- a/src/SQLInventory/Data/Entities/InstanceTag.cs
+++ b/src/SQLInventory/Data/Entities/InstanceTag.cs
@@ -1,0 +1,10 @@
+namespace SQLInventory.Data.Entities;
+
+public class InstanceTag
+{
+    public int InstanceId { get; set; }
+    public int TagId { get; set; }
+
+    public SqlInstance Instance { get; set; } = null!;
+    public Tag Tag { get; set; } = null!;
+}

--- a/src/SQLInventory/Data/Entities/SqlDatabase.cs
+++ b/src/SQLInventory/Data/Entities/SqlDatabase.cs
@@ -1,0 +1,23 @@
+namespace SQLInventory.Data.Entities;
+
+public class SqlDatabase
+{
+    public int DatabaseId { get; set; }
+    public int InstanceId { get; set; }
+    public string DatabaseName { get; set; } = "";
+    public decimal? SizeMb { get; set; }
+    public int? CompatibilityLevel { get; set; }
+    public string? RecoveryModel { get; set; }
+    public string? StateDesc { get; set; }
+    public bool IsReadOnly { get; set; }
+    public string? Owner { get; set; }
+    public string? CollationName { get; set; }
+    public DateTime? LastFullBackupUtc { get; set; }
+    public DateTime? LastLogBackupUtc { get; set; }
+    public DateTime CreatedUtc { get; set; }
+    public DateTime ModifiedUtc { get; set; }
+
+    public SqlInstance Instance { get; set; } = null!;
+
+    public decimal? SizeGb => SizeMb.HasValue ? Math.Round(SizeMb.Value / 1024, 2) : null;
+}

--- a/src/SQLInventory/Data/Entities/SqlInstance.cs
+++ b/src/SQLInventory/Data/Entities/SqlInstance.cs
@@ -1,0 +1,38 @@
+namespace SQLInventory.Data.Entities;
+
+public class SqlInstance
+{
+    public int InstanceId { get; set; }
+    public string ServerName { get; set; } = "";
+    public string? InstanceName { get; set; }
+    public int Port { get; set; } = 1433;
+    public int EnvironmentId { get; set; }
+    public string? SqlVersion { get; set; }
+    public string? SqlEdition { get; set; }
+    public string? SqlBuild { get; set; }
+    public string? HostOperatingSystem { get; set; }
+    public bool IsClustered { get; set; }
+    public bool IsAlwaysOnEnabled { get; set; }
+    public int? MaxMemoryMb { get; set; }
+    public int? CpuCount { get; set; }
+    public string? ServiceAccount { get; set; }
+    public string? Notes { get; set; }
+    public bool IsActive { get; set; } = true;
+    public DateTime? LastDiscoveredUtc { get; set; }
+    public DateTime CreatedUtc { get; set; }
+    public DateTime ModifiedUtc { get; set; }
+
+    public Environment Environment { get; set; } = null!;
+    public ICollection<SqlDatabase> Databases { get; set; } = [];
+    public ICollection<InstanceTag> InstanceTags { get; set; } = [];
+    public ICollection<AvailabilityGroup> PrimaryAvailabilityGroups { get; set; } = [];
+    public ICollection<AgReplica> AgReplicas { get; set; } = [];
+
+    public string FullName => InstanceName is not null
+        ? $"{ServerName}\\{InstanceName}"
+        : ServerName;
+
+    public string ConnectionName => Port != 1433
+        ? $"{FullName},{Port}"
+        : FullName;
+}

--- a/src/SQLInventory/Data/Entities/Tag.cs
+++ b/src/SQLInventory/Data/Entities/Tag.cs
@@ -1,0 +1,10 @@
+namespace SQLInventory.Data.Entities;
+
+public class Tag
+{
+    public int TagId { get; set; }
+    public string Name { get; set; } = "";
+    public string ColorHex { get; set; } = "#0d6efd";
+
+    public ICollection<InstanceTag> InstanceTags { get; set; } = [];
+}

--- a/src/SQLInventory/Pages/AvailabilityGroups/Index.razor
+++ b/src/SQLInventory/Pages/AvailabilityGroups/Index.razor
@@ -1,0 +1,181 @@
+@page "/availability-groups"
+@inject AvailabilityGroupService AgService
+@inject InstanceService InstanceService
+
+<PageTitle>Availability Groups - SQL Inventory</PageTitle>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h4 class="mb-0"><i class="bi bi-diagram-3 me-2"></i>Availability Groups</h4>
+    <button class="btn btn-primary btn-sm" @onclick="() => _showAdd = true">
+        <i class="bi bi-plus-lg me-1"></i>Add AG
+    </button>
+</div>
+
+@if (_loading)
+{
+    <div class="text-muted d-flex gap-2"><div class="spinner-border spinner-border-sm"></div> Loading...</div>
+}
+else if (_ags.Count == 0)
+{
+    <div class="card shadow-sm p-4 text-center text-muted">
+        No availability groups registered. Add one manually or use Discovery.
+    </div>
+}
+else
+{
+    @foreach (var ag in _ags)
+    {
+        <div class="card shadow-sm mb-3">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <div>
+                    <span class="fw-semibold fs-6">@ag.AgName</span>
+                    @if (ag.ClusterType is not null)
+                    {
+                        <span class="badge bg-secondary ms-2">@ag.ClusterType</span>
+                    }
+                </div>
+                <div class="d-flex gap-2">
+                    <span class="text-muted small">Primary: <strong>@ag.PrimaryInstance.FullName</strong></span>
+                    <button class="btn btn-outline-danger btn-sm" @onclick="() => DeleteAgAsync(ag.AgId)">
+                        <i class="bi bi-trash"></i>
+                    </button>
+                </div>
+            </div>
+            @if (ag.Replicas.Count > 0)
+            {
+                <div class="card-body p-0">
+                    <table class="table table-sm mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Replica</th>
+                                <th>Role</th>
+                                <th>Availability Mode</th>
+                                <th>Failover Mode</th>
+                                <th>Seeding Mode</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var r in ag.Replicas.OrderBy(r => r.Role))
+                            {
+                                <tr>
+                                    <td>
+                                        <a href="/instances/@r.InstanceId" class="text-decoration-none">
+                                            @r.Instance.FullName
+                                        </a>
+                                    </td>
+                                    <td>
+                                        <span class="badge @(r.Role == "PRIMARY" ? "bg-primary" : "bg-secondary")">
+                                            @r.Role
+                                        </span>
+                                    </td>
+                                    <td class="small">@(r.AvailabilityMode ?? "—")</td>
+                                    <td class="small">@(r.FailoverMode ?? "—")</td>
+                                    <td class="small">@(r.SeedingMode ?? "—")</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+            @if (!string.IsNullOrWhiteSpace(ag.Notes))
+            {
+                <div class="card-footer text-muted small">@ag.Notes</div>
+            }
+        </div>
+    }
+}
+
+@if (_showAdd)
+{
+    <div class="modal d-block" tabindex="-1" style="background:rgba(0,0,0,.4)">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Add Availability Group</h5>
+                    <button class="btn-close" @onclick="() => _showAdd = false"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">AG Name <span class="text-danger">*</span></label>
+                        <input class="form-control" @bind="_newAg.AgName" />
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Primary Instance <span class="text-danger">*</span></label>
+                        <select class="form-select" @bind="_newAg.PrimaryInstanceId">
+                            <option value="0">-- select --</option>
+                            @foreach (var inst in _allInstances)
+                            {
+                                <option value="@inst.InstanceId">@inst.FullName</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="row g-2">
+                        <div class="col-6">
+                            <label class="form-label">Cluster Type</label>
+                            <select class="form-select" @bind="_newAg.ClusterType">
+                                <option value="">—</option>
+                                <option>WSFC</option>
+                                <option>NONE</option>
+                                <option>EXTERNAL</option>
+                            </select>
+                        </div>
+                        <div class="col-6">
+                            <label class="form-label">Backup Preference</label>
+                            <select class="form-select" @bind="_newAg.AutomatedBackupPreference">
+                                <option value="">—</option>
+                                <option>PRIMARY</option>
+                                <option>SECONDARY_ONLY</option>
+                                <option>SECONDARY</option>
+                                <option>NONE</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="mt-3">
+                        <label class="form-label">Notes</label>
+                        <textarea class="form-control" rows="2" @bind="_newAg.Notes"></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-secondary" @onclick="() => _showAdd = false">Cancel</button>
+                    <button class="btn btn-primary" @onclick="SaveAgAsync">Save</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private List<AvailabilityGroup> _ags = [];
+    private List<SqlInstance> _allInstances = [];
+    private bool _loading = true;
+    private bool _showAdd;
+    private AvailabilityGroup _newAg = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        _allInstances = await InstanceService.GetAllAsync();
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        _ags = await AgService.GetAllAsync();
+        _loading = false;
+    }
+
+    private async Task SaveAgAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_newAg.AgName) || _newAg.PrimaryInstanceId == 0) return;
+        await AgService.CreateAsync(_newAg);
+        _newAg = new AvailabilityGroup();
+        _showAdd = false;
+        await LoadAsync();
+    }
+
+    private async Task DeleteAgAsync(int agId)
+    {
+        await AgService.DeleteAsync(agId);
+        await LoadAsync();
+    }
+}

--- a/src/SQLInventory/Pages/Dashboard.razor
+++ b/src/SQLInventory/Pages/Dashboard.razor
@@ -1,0 +1,138 @@
+@page "/"
+@inject InstanceService InstanceService
+
+<PageTitle>Dashboard - SQL Inventory</PageTitle>
+
+<h4 class="mb-4"><i class="bi bi-speedometer2 me-2"></i>Dashboard</h4>
+
+@if (_stats is null)
+{
+    <div class="d-flex align-items-center gap-2 text-muted">
+        <div class="spinner-border spinner-border-sm"></div> Loading...
+    </div>
+}
+else
+{
+    <div class="row g-3 mb-4">
+        <div class="col-md-4">
+            <div class="card stat-card shadow-sm h-100">
+                <div class="card-body d-flex align-items-center gap-3">
+                    <div class="rounded-circle bg-primary bg-opacity-10 p-3">
+                        <i class="bi bi-server fs-3 text-primary"></i>
+                    </div>
+                    <div>
+                        <div class="fs-2 fw-bold">@_stats.ActiveInstances</div>
+                        <div class="text-muted small">Active Instances</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card stat-card shadow-sm h-100">
+                <div class="card-body d-flex align-items-center gap-3">
+                    <div class="rounded-circle bg-success bg-opacity-10 p-3">
+                        <i class="bi bi-database fs-3 text-success"></i>
+                    </div>
+                    <div>
+                        <div class="fs-2 fw-bold">@_stats.TotalDatabases</div>
+                        <div class="text-muted small">Total Databases</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card stat-card shadow-sm h-100">
+                <div class="card-body d-flex align-items-center gap-3">
+                    <div class="rounded-circle bg-warning bg-opacity-10 p-3">
+                        <i class="bi bi-diagram-3 fs-3 text-warning"></i>
+                    </div>
+                    <div>
+                        <div class="fs-2 fw-bold">@_stats.AvailabilityGroups</div>
+                        <div class="text-muted small">Availability Groups</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-3">
+        <div class="col-md-5">
+            <div class="card shadow-sm">
+                <div class="card-header fw-semibold">Instances by Environment</div>
+                <div class="card-body">
+                    @if (_stats.ByEnvironment.Count == 0)
+                    {
+                        <p class="text-muted mb-0">No instances yet.</p>
+                    }
+                    else
+                    {
+                        @foreach (var env in _stats.ByEnvironment.OrderByDescending(e => e.Count))
+                        {
+                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                <span class="badge-env" style="background-color:@env.ColorHex">@env.Name</span>
+                                <span class="fw-semibold">@env.Count</span>
+                            </div>
+                            <div class="progress mb-3" style="height:6px">
+                                <div class="progress-bar" role="progressbar"
+                                     style="width:@(env.Count * 100 / Math.Max(_stats.ActiveInstances, 1))%;background-color:@env.ColorHex">
+                                </div>
+                            </div>
+                        }
+                    }
+                </div>
+            </div>
+        </div>
+        <div class="col-md-7">
+            <div class="card shadow-sm">
+                <div class="card-header fw-semibold">Recently Modified Instances</div>
+                <div class="card-body p-0">
+                    @if (_stats.RecentlyModified.Count == 0)
+                    {
+                        <p class="text-muted p-3 mb-0">No instances yet.</p>
+                    }
+                    else
+                    {
+                        <table class="table table-sm table-hover mb-0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>Instance</th>
+                                    <th>Environment</th>
+                                    <th>Version</th>
+                                    <th>Modified</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var inst in _stats.RecentlyModified)
+                                {
+                                    <tr>
+                                        <td>
+                                            <a href="instances/@inst.InstanceId" class="text-decoration-none fw-semibold">
+                                                @inst.FullName
+                                            </a>
+                                        </td>
+                                        <td>
+                                            <span class="badge-env" style="background-color:@inst.Environment.ColorHex">
+                                                @inst.Environment.Name
+                                            </span>
+                                        </td>
+                                        <td>@(inst.SqlVersion ?? "—")</td>
+                                        <td class="text-muted small">@inst.ModifiedUtc.ToString("yyyy-MM-dd")</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private DashboardStats? _stats;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _stats = await InstanceService.GetDashboardStatsAsync();
+    }
+}

--- a/src/SQLInventory/Pages/Databases/Index.razor
+++ b/src/SQLInventory/Pages/Databases/Index.razor
@@ -1,0 +1,116 @@
+@page "/databases"
+@inject DatabaseService DatabaseService
+@inject InstanceService InstanceService
+
+<PageTitle>Databases - SQL Inventory</PageTitle>
+
+<h4 class="mb-3"><i class="bi bi-database me-2"></i>Databases</h4>
+
+<div class="card shadow-sm mb-3">
+    <div class="card-body py-2">
+        <div class="row g-2 align-items-center">
+            <div class="col-md-4">
+                <input class="form-control form-control-sm" placeholder="Search database name..."
+                       @bind="_search" @bind:event="oninput" @oninput="ApplyFilter" />
+            </div>
+            <div class="col-md-4">
+                <select class="form-select form-select-sm" @bind="_instanceFilter" @bind:after="LoadAsync">
+                    <option value="0">All instances</option>
+                    @foreach (var inst in _instances)
+                    {
+                        <option value="@inst.InstanceId">@inst.FullName</option>
+                    }
+                </select>
+            </div>
+            <div class="col-md-4 text-end text-muted small">
+                @_filtered.Count result(s)
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card shadow-sm">
+    <div class="card-body p-0">
+        @if (_loading)
+        {
+            <div class="p-3 text-muted d-flex gap-2"><div class="spinner-border spinner-border-sm"></div> Loading...</div>
+        }
+        else if (_filtered.Count == 0)
+        {
+            <p class="text-muted p-3 mb-0">No databases found.</p>
+        }
+        else
+        {
+            <table class="table table-hover table-sm mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th>Database</th>
+                        <th>Instance</th>
+                        <th>State</th>
+                        <th>Recovery</th>
+                        <th>Compat Level</th>
+                        <th class="text-end">Size (GB)</th>
+                        <th>Last Full Backup</th>
+                        <th>Last Log Backup</th>
+                        <th>Owner</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var db in _filtered)
+                    {
+                        <tr>
+                            <td class="fw-semibold">@db.DatabaseName</td>
+                            <td>
+                                <a href="/instances/@db.InstanceId" class="text-decoration-none">
+                                    @db.Instance.FullName
+                                </a>
+                            </td>
+                            <td>
+                                <span class="badge @(db.StateDesc == "ONLINE" ? "bg-success" : "bg-warning text-dark")">
+                                    @(db.StateDesc ?? "—")
+                                </span>
+                            </td>
+                            <td class="text-muted small">@(db.RecoveryModel ?? "—")</td>
+                            <td class="text-muted small">@(db.CompatibilityLevel?.ToString() ?? "—")</td>
+                            <td class="text-end">@(db.SizeGb?.ToString("N2") ?? "—")</td>
+                            <td class="text-muted small">@(db.LastFullBackupUtc?.ToString("yyyy-MM-dd") ?? "Never")</td>
+                            <td class="text-muted small">@(db.LastLogBackupUtc?.ToString("yyyy-MM-dd") ?? "—")</td>
+                            <td class="text-muted small">@(db.Owner ?? "—")</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+    </div>
+</div>
+
+@code {
+    private List<SqlDatabase> _all = [];
+    private List<SqlDatabase> _filtered = [];
+    private List<SqlInstance> _instances = [];
+    private string _search = "";
+    private int _instanceFilter;
+    private bool _loading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _instances = await InstanceService.GetAllAsync();
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        StateHasChanged();
+        _all = await DatabaseService.GetAllAsync(_instanceFilter == 0 ? null : _instanceFilter);
+        ApplyFilter();
+        _loading = false;
+    }
+
+    private void ApplyFilter()
+    {
+        _filtered = string.IsNullOrWhiteSpace(_search)
+            ? _all
+            : _all.Where(d => d.DatabaseName.Contains(_search, StringComparison.OrdinalIgnoreCase)).ToList();
+    }
+}

--- a/src/SQLInventory/Pages/Discovery/Index.razor
+++ b/src/SQLInventory/Pages/Discovery/Index.razor
@@ -1,0 +1,228 @@
+@page "/discovery"
+@inject DiscoveryService DiscoveryService
+@inject InstanceService InstanceService
+@inject NavigationManager Nav
+
+<PageTitle>Discovery - SQL Inventory</PageTitle>
+
+<h4 class="mb-1"><i class="bi bi-search me-2"></i>Instance Discovery</h4>
+<p class="text-muted mb-4">Connect to a live SQL Server instance to import its metadata into the inventory.</p>
+
+<div class="row g-4">
+    <div class="col-md-5">
+        <div class="card shadow-sm">
+            <div class="card-header fw-semibold">Connection Details</div>
+            <div class="card-body">
+                <div class="mb-3">
+                    <label class="form-label">Server Name <span class="text-danger">*</span></label>
+                    <input class="form-control" @bind="_server" placeholder="SQL-PROD-01" />
+                </div>
+                <div class="row g-2 mb-3">
+                    <div class="col-8">
+                        <label class="form-label">Instance Name</label>
+                        <input class="form-control" @bind="_instanceName" placeholder="(default instance)" />
+                    </div>
+                    <div class="col-4">
+                        <label class="form-label">Port</label>
+                        <input class="form-control" type="number" @bind="_port" />
+                    </div>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Environment <span class="text-danger">*</span></label>
+                    <select class="form-select" @bind="_environmentId">
+                        <option value="0">-- select --</option>
+                        @foreach (var env in _environments)
+                        {
+                            <option value="@env.EnvironmentId">@env.Name</option>
+                        }
+                    </select>
+                </div>
+
+                <div class="border rounded p-3 mb-3 bg-light">
+                    <div class="form-check mb-2">
+                        <input class="form-check-input" type="radio" id="authWin" name="auth"
+                               checked="@_useWindowsAuth" @onchange="() => _useWindowsAuth = true" />
+                        <label class="form-check-label" for="authWin">Windows / Integrated Auth</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" id="authSQL" name="auth"
+                               checked="@(!_useWindowsAuth)" @onchange="() => _useWindowsAuth = false" />
+                        <label class="form-check-label" for="authSQL">SQL Server Auth</label>
+                    </div>
+
+                    @if (!_useWindowsAuth)
+                    {
+                        <div class="mt-2">
+                            <input class="form-control form-control-sm mb-2" @bind="_username" placeholder="Username" />
+                            <input class="form-control form-control-sm" type="password" @bind="_password" placeholder="Password" />
+                        </div>
+                    }
+                </div>
+
+                <button class="btn btn-primary w-100" @onclick="RunDiscoveryAsync" disabled="@(_discovering || string.IsNullOrWhiteSpace(_server) || _environmentId == 0)">
+                    @if (_discovering)
+                    {
+                        <span class="spinner-border spinner-border-sm me-1"></span>
+                        <span>Connecting...</span>
+                    }
+                    else
+                    {
+                        <i class="bi bi-search me-1"></i>
+                        <span>Discover</span>
+                    }
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-md-7">
+        @if (_result is not null)
+        {
+            @if (!_result.Success)
+            {
+                <div class="alert alert-danger">
+                    <strong><i class="bi bi-exclamation-triangle me-1"></i>Connection failed</strong>
+                    <div class="mt-1 small">@_result.ErrorMessage</div>
+                </div>
+            }
+            else
+            {
+                <div class="card shadow-sm mb-3">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <span class="fw-semibold text-success">
+                            <i class="bi bi-check-circle me-1"></i>Discovery successful
+                        </span>
+                        <button class="btn btn-success btn-sm" @onclick="ImportAsync" disabled="@_importing">
+                            @if (_importing) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                            <i class="bi bi-cloud-download me-1"></i>Import into Inventory
+                        </button>
+                    </div>
+                    <div class="card-body">
+                        <h6 class="text-muted text-uppercase small mb-2">Instance</h6>
+                        <dl class="row mb-0">
+                            <dt class="col-5 text-muted">Full Name</dt>
+                            <dd class="col-7">@_result.Instance!.FullName</dd>
+                            <dt class="col-5 text-muted">SQL Version</dt>
+                            <dd class="col-7">@($"SQL {_result.Instance.SqlVersion} ({_result.Instance.SqlBuild})")</dd>
+                            <dt class="col-5 text-muted">Edition</dt>
+                            <dd class="col-7">@(_result.Instance.SqlEdition ?? "—")</dd>
+                            <dt class="col-5 text-muted">Host OS</dt>
+                            <dd class="col-7">@(_result.Instance.HostOperatingSystem ?? "—")</dd>
+                            <dt class="col-5 text-muted">CPUs</dt>
+                            <dd class="col-7">@(_result.Instance.CpuCount?.ToString() ?? "—")</dd>
+                            <dt class="col-5 text-muted">Max Memory</dt>
+                            <dd class="col-7">@(_result.Instance.MaxMemoryMb.HasValue ? $"{_result.Instance.MaxMemoryMb:N0} MB" : "—")</dd>
+                            <dt class="col-5 text-muted">Always On</dt>
+                            <dd class="col-7">@(_result.Instance.IsAlwaysOnEnabled ? "Yes" : "No")</dd>
+                            <dt class="col-5 text-muted">Clustered</dt>
+                            <dd class="col-7">@(_result.Instance.IsClustered ? "Yes" : "No")</dd>
+                        </dl>
+                    </div>
+                </div>
+
+                @if (_result.Databases.Count > 0)
+                {
+                    <div class="card shadow-sm mb-3">
+                        <div class="card-header fw-semibold">
+                            <i class="bi bi-database me-1"></i>@_result.Databases.Count User Database(s)
+                        </div>
+                        <div class="card-body p-0">
+                            <table class="table table-sm mb-0">
+                                <thead class="table-light">
+                                    <tr><th>Name</th><th>State</th><th>Recovery</th><th class="text-end">Size (MB)</th></tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var db in _result.Databases.OrderBy(d => d.DatabaseName))
+                                    {
+                                        <tr>
+                                            <td>@db.DatabaseName</td>
+                                            <td><span class="badge @(db.StateDesc == "ONLINE" ? "bg-success" : "bg-warning text-dark")">@db.StateDesc</span></td>
+                                            <td class="small">@(db.RecoveryModel ?? "—")</td>
+                                            <td class="text-end small">@(db.SizeMb?.ToString("N0") ?? "—")</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                }
+
+                @if (_result.AvailabilityGroups.Count > 0)
+                {
+                    <div class="card shadow-sm">
+                        <div class="card-header fw-semibold">
+                            <i class="bi bi-diagram-3 me-1"></i>@_result.AvailabilityGroups.Count Availability Group(s)
+                        </div>
+                        <div class="card-body">
+                            @foreach (var ag in _result.AvailabilityGroups)
+                            {
+                                <div class="mb-2">
+                                    <strong>@ag.AgName</strong>
+                                    <span class="text-muted small ms-2">@ag.ClusterType</span>
+                                    <ul class="mb-0 small">
+                                        @foreach (var r in ag.Replicas)
+                                        {
+                                            <li>@r.ReplicaServerName — <strong>@r.Role</strong> (@r.AvailabilityMode)</li>
+                                        }
+                                    </ul>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                }
+            }
+        }
+        else if (!_discovering)
+        {
+            <div class="card shadow-sm border-dashed">
+                <div class="card-body text-center text-muted py-5">
+                    <i class="bi bi-search fs-1 mb-3 d-block opacity-25"></i>
+                    <p class="mb-0">Fill in the connection details and click <strong>Discover</strong> to preview the instance metadata before importing.</p>
+                </div>
+            </div>
+        }
+    </div>
+</div>
+
+@code {
+    private List<Environment> _environments = [];
+    private string _server = "";
+    private string? _instanceName;
+    private int _port = 1433;
+    private int _environmentId;
+    private bool _useWindowsAuth = true;
+    private string? _username;
+    private string? _password;
+    private bool _discovering;
+    private bool _importing;
+    private DiscoveryResult? _result;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _environments = await InstanceService.GetEnvironmentsAsync();
+    }
+
+    private async Task RunDiscoveryAsync()
+    {
+        _discovering = true;
+        _result = null;
+        StateHasChanged();
+        _result = await DiscoveryService.DiscoverAsync(
+            _server,
+            string.IsNullOrWhiteSpace(_instanceName) ? null : _instanceName,
+            _port,
+            _useWindowsAuth ? null : _username,
+            _useWindowsAuth ? null : _password,
+            _environmentId);
+        _discovering = false;
+    }
+
+    private async Task ImportAsync()
+    {
+        if (_result is null || !_result.Success) return;
+        _importing = true;
+        var instance = await DiscoveryService.ImportAsync(_result, _environmentId);
+        _importing = false;
+        Nav.NavigateTo($"/instances/{instance.InstanceId}");
+    }
+}

--- a/src/SQLInventory/Pages/Instances/Detail.razor
+++ b/src/SQLInventory/Pages/Instances/Detail.razor
@@ -1,0 +1,288 @@
+@page "/instances/{Id:int}"
+@inject InstanceService InstanceService
+@inject DatabaseService DatabaseService
+@inject NavigationManager Nav
+
+<PageTitle>@(_instance?.FullName ?? "Instance") - SQL Inventory</PageTitle>
+
+@if (_instance is null)
+{
+    <div class="text-muted d-flex gap-2"><div class="spinner-border spinner-border-sm"></div> Loading...</div>
+}
+else
+{
+    <div class="d-flex justify-content-between align-items-start mb-3">
+        <div class="d-flex align-items-center gap-2">
+            <a href="/instances" class="btn btn-outline-secondary btn-sm"><i class="bi bi-arrow-left"></i></a>
+            <div>
+                <h4 class="mb-0">@_instance.FullName</h4>
+                <small class="text-muted">@_instance.ConnectionName</small>
+            </div>
+        </div>
+        <div class="d-flex gap-2">
+            <a href="/instances/@_instance.InstanceId/edit" class="btn btn-outline-primary btn-sm">
+                <i class="bi bi-pencil me-1"></i>Edit
+            </a>
+        </div>
+    </div>
+
+    <div class="row g-3 mb-3">
+        <div class="col-md-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header fw-semibold">Instance Details</div>
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        <dt class="col-5 text-muted">Environment</dt>
+                        <dd class="col-7">
+                            <span class="badge-env" style="background-color:@_instance.Environment.ColorHex">
+                                @_instance.Environment.Name
+                            </span>
+                        </dd>
+
+                        <dt class="col-5 text-muted">SQL Version</dt>
+                        <dd class="col-7">@(string.IsNullOrEmpty(_instance.SqlVersion) ? "—" : $"SQL {_instance.SqlVersion} {_instance.SqlEdition}")</dd>
+
+                        <dt class="col-5 text-muted">Build</dt>
+                        <dd class="col-7">@(_instance.SqlBuild ?? "—")</dd>
+
+                        <dt class="col-5 text-muted">Host OS</dt>
+                        <dd class="col-7">@(_instance.HostOperatingSystem ?? "—")</dd>
+
+                        <dt class="col-5 text-muted">CPU Count</dt>
+                        <dd class="col-7">@(_instance.CpuCount?.ToString() ?? "—")</dd>
+
+                        <dt class="col-5 text-muted">Max Memory</dt>
+                        <dd class="col-7">@(_instance.MaxMemoryMb.HasValue ? $"{_instance.MaxMemoryMb:N0} MB" : "—")</dd>
+
+                        <dt class="col-5 text-muted">Service Account</dt>
+                        <dd class="col-7">@(_instance.ServiceAccount ?? "—")</dd>
+
+                        <dt class="col-5 text-muted">Clustered</dt>
+                        <dd class="col-7">
+                            @if (_instance.IsClustered)
+                            { <span class="badge bg-info">Yes</span> }
+                            else
+                            { <span class="text-muted">No</span> }
+                        </dd>
+
+                        <dt class="col-5 text-muted">Always On</dt>
+                        <dd class="col-7">
+                            @if (_instance.IsAlwaysOnEnabled)
+                            { <span class="badge bg-success">Enabled</span> }
+                            else
+                            { <span class="text-muted">No</span> }
+                        </dd>
+
+                        <dt class="col-5 text-muted">Status</dt>
+                        <dd class="col-7">
+                            @if (_instance.IsActive)
+                            { <span class="badge bg-success">Active</span> }
+                            else
+                            { <span class="badge bg-secondary">Inactive</span> }
+                        </dd>
+
+                        @if (_instance.LastDiscoveredUtc.HasValue)
+                        {
+                            <dt class="col-5 text-muted">Last Discovered</dt>
+                            <dd class="col-7">@_instance.LastDiscoveredUtc.Value.ToString("yyyy-MM-dd HH:mm") UTC</dd>
+                        }
+                    </dl>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header fw-semibold">Tags &amp; Notes</div>
+                <div class="card-body">
+                    <div class="mb-3">
+                        @if (_instance.InstanceTags.Count == 0)
+                        {
+                            <span class="text-muted">No tags</span>
+                        }
+                        @foreach (var it in _instance.InstanceTags)
+                        {
+                            <span class="badge me-1 mb-1" style="background-color:@it.Tag.ColorHex">@it.Tag.Name</span>
+                        }
+                    </div>
+                    @if (!string.IsNullOrWhiteSpace(_instance.Notes))
+                    {
+                        <p class="mb-0" style="white-space:pre-wrap">@_instance.Notes</p>
+                    }
+                    else
+                    {
+                        <span class="text-muted">No notes</span>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Databases -->
+    <div class="card shadow-sm mb-3">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <span class="fw-semibold"><i class="bi bi-database me-1"></i>Databases (@_instance.Databases.Count)</span>
+            <button class="btn btn-outline-primary btn-sm" @onclick="ShowAddDb">
+                <i class="bi bi-plus-lg me-1"></i>Add Database
+            </button>
+        </div>
+        <div class="card-body p-0">
+            @if (_instance.Databases.Count == 0)
+            {
+                <p class="text-muted p-3 mb-0">No databases registered.</p>
+            }
+            else
+            {
+                <table class="table table-sm table-hover mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Name</th>
+                            <th>State</th>
+                            <th>Recovery</th>
+                            <th>Compat</th>
+                            <th class="text-end">Size (GB)</th>
+                            <th>Last Full Backup</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var db in _instance.Databases.OrderBy(d => d.DatabaseName))
+                        {
+                            <tr>
+                                <td class="fw-semibold">@db.DatabaseName</td>
+                                <td>
+                                    <span class="badge @(db.StateDesc == "ONLINE" ? "bg-success" : "bg-warning text-dark")">
+                                        @(db.StateDesc ?? "—")
+                                    </span>
+                                </td>
+                                <td>@(db.RecoveryModel ?? "—")</td>
+                                <td>@(db.CompatibilityLevel?.ToString() ?? "—")</td>
+                                <td class="text-end">@(db.SizeGb?.ToString("N2") ?? "—")</td>
+                                <td class="text-muted small">
+                                    @(db.LastFullBackupUtc?.ToString("yyyy-MM-dd") ?? "Never")
+                                </td>
+                                <td class="text-end">
+                                    <button class="btn btn-outline-danger btn-sm"
+                                            @onclick="() => DeleteDbAsync(db.DatabaseId)">
+                                        <i class="bi bi-trash"></i>
+                                    </button>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            }
+        </div>
+    </div>
+
+    <!-- Availability Groups -->
+    @if (_instance.PrimaryAvailabilityGroups.Count > 0 || _instance.AgReplicas.Count > 0)
+    {
+        <div class="card shadow-sm">
+            <div class="card-header fw-semibold"><i class="bi bi-diagram-3 me-1"></i>Availability Groups</div>
+            <div class="card-body">
+                @foreach (var ag in _instance.PrimaryAvailabilityGroups)
+                {
+                    <h6>@ag.AgName
+                        <span class="badge bg-secondary ms-2">@(ag.ClusterType ?? "WSFC")</span>
+                    </h6>
+                    <table class="table table-sm table-bordered mb-3">
+                        <thead class="table-light">
+                            <tr><th>Replica</th><th>Role</th><th>Availability Mode</th><th>Failover Mode</th></tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var r in ag.Replicas)
+                            {
+                                <tr>
+                                    <td>@r.Instance.FullName</td>
+                                    <td><span class="badge @(r.Role == "PRIMARY" ? "bg-primary" : "bg-secondary")">@r.Role</span></td>
+                                    <td>@(r.AvailabilityMode ?? "—")</td>
+                                    <td>@(r.FailoverMode ?? "—")</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+            </div>
+        </div>
+    }
+}
+
+<!-- Add DB modal -->
+@if (_showAddDb)
+{
+    <div class="modal d-block" tabindex="-1" style="background:rgba(0,0,0,.4)">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Add Database</h5>
+                    <button class="btn-close" @onclick="() => _showAddDb = false"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">Database Name <span class="text-danger">*</span></label>
+                        <input class="form-control" @bind="_newDb.DatabaseName" />
+                    </div>
+                    <div class="row g-2">
+                        <div class="col-6">
+                            <label class="form-label">Recovery Model</label>
+                            <select class="form-select" @bind="_newDb.RecoveryModel">
+                                <option value="">—</option>
+                                <option>FULL</option>
+                                <option>SIMPLE</option>
+                                <option>BULK_LOGGED</option>
+                            </select>
+                        </div>
+                        <div class="col-6">
+                            <label class="form-label">State</label>
+                            <select class="form-select" @bind="_newDb.StateDesc">
+                                <option>ONLINE</option>
+                                <option>OFFLINE</option>
+                                <option>RESTORING</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-secondary" @onclick="() => _showAddDb = false">Cancel</button>
+                    <button class="btn btn-primary" @onclick="SaveDbAsync">Save</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public int Id { get; set; }
+
+    private SqlInstance? _instance;
+    private bool _showAddDb;
+    private SqlDatabase _newDb = new();
+
+    protected override async Task OnParametersSetAsync() => await ReloadAsync();
+
+    private async Task ReloadAsync()
+    {
+        _instance = await InstanceService.GetByIdAsync(Id);
+        if (_instance is null) Nav.NavigateTo("/instances");
+    }
+
+    private void ShowAddDb()
+    {
+        _newDb = new SqlDatabase { InstanceId = Id, StateDesc = "ONLINE" };
+        _showAddDb = true;
+    }
+
+    private async Task SaveDbAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_newDb.DatabaseName)) return;
+        await DatabaseService.CreateAsync(_newDb);
+        _showAddDb = false;
+        await ReloadAsync();
+    }
+
+    private async Task DeleteDbAsync(int dbId)
+    {
+        await DatabaseService.DeleteAsync(dbId);
+        await ReloadAsync();
+    }
+}

--- a/src/SQLInventory/Pages/Instances/Edit.razor
+++ b/src/SQLInventory/Pages/Instances/Edit.razor
@@ -1,0 +1,220 @@
+@page "/instances/new"
+@page "/instances/{Id:int}/edit"
+@inject InstanceService InstanceService
+@inject TagService TagService
+@inject NavigationManager Nav
+
+<PageTitle>@(_isNew ? "Add Instance" : "Edit Instance") - SQL Inventory</PageTitle>
+
+<div class="d-flex align-items-center gap-2 mb-3">
+    <a href="/instances" class="btn btn-outline-secondary btn-sm"><i class="bi bi-arrow-left"></i></a>
+    <h4 class="mb-0">@(_isNew ? "Add Instance" : $"Edit: {_model.ServerName}")</h4>
+</div>
+
+@if (_loading)
+{
+    <div class="text-muted d-flex gap-2"><div class="spinner-border spinner-border-sm"></div> Loading...</div>
+}
+else
+{
+    <div class="card shadow-sm" style="max-width:760px">
+        <div class="card-body">
+            <EditForm Model="_model" OnValidSubmit="SaveAsync">
+                <DataAnnotationsValidator />
+
+                <h6 class="text-muted mb-3 text-uppercase small">Connection</h6>
+                <div class="row g-3 mb-3">
+                    <div class="col-md-6">
+                        <label class="form-label">Server Name <span class="text-danger">*</span></label>
+                        <InputText class="form-control" @bind-Value="_model.ServerName" placeholder="SQL-PROD-01" />
+                        <ValidationMessage For="() => _model.ServerName" />
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Instance Name</label>
+                        <InputText class="form-control" @bind-Value="_model.InstanceName" placeholder="(default)" />
+                    </div>
+                    <div class="col-md-2">
+                        <label class="form-label">Port</label>
+                        <InputNumber class="form-control" @bind-Value="_model.Port" />
+                    </div>
+                </div>
+
+                <h6 class="text-muted mb-3 text-uppercase small">Classification</h6>
+                <div class="row g-3 mb-3">
+                    <div class="col-md-4">
+                        <label class="form-label">Environment <span class="text-danger">*</span></label>
+                        <InputSelect class="form-select" @bind-Value="_model.EnvironmentId">
+                            <option value="0">-- select --</option>
+                            @foreach (var env in _environments)
+                            {
+                                <option value="@env.EnvironmentId">@env.Name</option>
+                            }
+                        </InputSelect>
+                    </div>
+                    <div class="col-md-8">
+                        <label class="form-label">Tags</label>
+                        <div class="d-flex flex-wrap gap-2 border rounded p-2" style="min-height:38px">
+                            @foreach (var tag in _allTags)
+                            {
+                                var selected = _selectedTagIds.Contains(tag.TagId);
+                                <button type="button"
+                                        class="btn btn-sm @(selected ? "text-white" : "btn-outline-secondary")"
+                                        style="@(selected ? $"background-color:{tag.ColorHex};border-color:{tag.ColorHex}" : "")"
+                                        @onclick="() => ToggleTag(tag.TagId)">
+                                    @tag.Name
+                                </button>
+                            }
+                        </div>
+                    </div>
+                </div>
+
+                <h6 class="text-muted mb-3 text-uppercase small">SQL Server Details</h6>
+                <div class="row g-3 mb-3">
+                    <div class="col-md-3">
+                        <label class="form-label">Version</label>
+                        <InputSelect class="form-select" @bind-Value="_model.SqlVersion">
+                            <option value="">Unknown</option>
+                            <option>2022</option>
+                            <option>2019</option>
+                            <option>2017</option>
+                            <option>2016</option>
+                            <option>2014</option>
+                            <option>2012</option>
+                        </InputSelect>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Edition</label>
+                        <InputSelect class="form-select" @bind-Value="_model.SqlEdition">
+                            <option value="">Unknown</option>
+                            <option>Enterprise</option>
+                            <option>Standard</option>
+                            <option>Developer</option>
+                            <option>Express</option>
+                            <option>Web</option>
+                        </InputSelect>
+                    </div>
+                    <div class="col-md-5">
+                        <label class="form-label">Build</label>
+                        <InputText class="form-control" @bind-Value="_model.SqlBuild" placeholder="e.g. 16.0.1000.6" />
+                    </div>
+                </div>
+
+                <div class="row g-3 mb-3">
+                    <div class="col-md-6">
+                        <label class="form-label">Host Operating System</label>
+                        <InputText class="form-control" @bind-Value="_model.HostOperatingSystem" placeholder="Windows Server 2022" />
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">CPU Count</label>
+                        <InputNumber class="form-control" @bind-Value="_model.CpuCount" />
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">Max Memory (MB)</label>
+                        <InputNumber class="form-control" @bind-Value="_model.MaxMemoryMb" />
+                    </div>
+                </div>
+
+                <div class="row g-3 mb-3">
+                    <div class="col-md-6">
+                        <label class="form-label">Service Account</label>
+                        <InputText class="form-control" @bind-Value="_model.ServiceAccount" placeholder="DOMAIN\svc_sql" />
+                    </div>
+                    <div class="col-md-3 d-flex align-items-end pb-1">
+                        <div class="form-check me-3">
+                            <InputCheckbox class="form-check-input" @bind-Value="_model.IsClustered" id="chkClustered" />
+                            <label class="form-check-label" for="chkClustered">Clustered</label>
+                        </div>
+                    </div>
+                    <div class="col-md-3 d-flex align-items-end pb-1">
+                        <div class="form-check me-3">
+                            <InputCheckbox class="form-check-input" @bind-Value="_model.IsAlwaysOnEnabled" id="chkAG" />
+                            <label class="form-check-label" for="chkAG">Always On</label>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Notes</label>
+                    <InputTextArea class="form-control" rows="3" @bind-Value="_model.Notes" />
+                </div>
+
+                <div class="form-check mb-4">
+                    <InputCheckbox class="form-check-input" @bind-Value="_model.IsActive" id="chkActive" />
+                    <label class="form-check-label" for="chkActive">Active</label>
+                </div>
+
+                @if (!string.IsNullOrEmpty(_error))
+                {
+                    <div class="alert alert-danger">@_error</div>
+                }
+
+                <div class="d-flex gap-2">
+                    <button type="submit" class="btn btn-primary" disabled="@_saving">
+                        @if (_saving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                        Save
+                    </button>
+                    <a href="/instances" class="btn btn-outline-secondary">Cancel</a>
+                </div>
+            </EditForm>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public int? Id { get; set; }
+
+    private SqlInstance _model = new() { Port = 1433, IsActive = true };
+    private List<Environment> _environments = [];
+    private List<Tag> _allTags = [];
+    private HashSet<int> _selectedTagIds = [];
+    private bool _isNew => Id is null;
+    private bool _loading = true;
+    private bool _saving;
+    private string? _error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _environments = await InstanceService.GetEnvironmentsAsync();
+        _allTags = await TagService.GetAllAsync();
+
+        if (!_isNew)
+        {
+            var instance = await InstanceService.GetByIdAsync(Id!.Value);
+            if (instance is null) { Nav.NavigateTo("/instances"); return; }
+            _model = instance;
+            _selectedTagIds = instance.InstanceTags.Select(it => it.TagId).ToHashSet();
+        }
+
+        _loading = false;
+    }
+
+    private void ToggleTag(int tagId)
+    {
+        if (!_selectedTagIds.Remove(tagId))
+            _selectedTagIds.Add(tagId);
+    }
+
+    private async Task SaveAsync()
+    {
+        _saving = true;
+        _error = null;
+        try
+        {
+            if (_isNew)
+                await InstanceService.CreateAsync(_model);
+            else
+                await InstanceService.UpdateAsync(_model);
+
+            await InstanceService.SetTagsAsync(_model.InstanceId, _selectedTagIds);
+            Nav.NavigateTo($"/instances/{_model.InstanceId}");
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+}

--- a/src/SQLInventory/Pages/Instances/Index.razor
+++ b/src/SQLInventory/Pages/Instances/Index.razor
@@ -1,0 +1,216 @@
+@page "/instances"
+@inject InstanceService InstanceService
+@inject NavigationManager Nav
+
+<PageTitle>Instances - SQL Inventory</PageTitle>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h4 class="mb-0"><i class="bi bi-server me-2"></i>SQL Instances</h4>
+    <a href="/instances/new" class="btn btn-primary btn-sm">
+        <i class="bi bi-plus-lg me-1"></i>Add Instance
+    </a>
+</div>
+
+<div class="card shadow-sm mb-3">
+    <div class="card-body py-2">
+        <div class="row g-2 align-items-center">
+            <div class="col-md-5">
+                <input class="form-control form-control-sm" placeholder="Search server name or notes..."
+                       @bind="_search" @bind:event="oninput" @oninput="LoadAsync" />
+            </div>
+            <div class="col-md-3">
+                <select class="form-select form-select-sm" @bind="_envFilter" @bind:after="LoadAsync">
+                    <option value="0">All environments</option>
+                    @foreach (var env in _environments)
+                    {
+                        <option value="@env.EnvironmentId">@env.Name</option>
+                    }
+                </select>
+            </div>
+            <div class="col-md-2">
+                <select class="form-select form-select-sm" @bind="_activeFilter" @bind:after="LoadAsync">
+                    <option value="">All</option>
+                    <option value="true">Active only</option>
+                    <option value="false">Inactive only</option>
+                </select>
+            </div>
+            <div class="col-md-2 text-end text-muted small">
+                @_instances.Count result(s)
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card shadow-sm">
+    <div class="card-body p-0">
+        @if (_loading)
+        {
+            <div class="p-3 text-muted d-flex gap-2 align-items-center">
+                <div class="spinner-border spinner-border-sm"></div> Loading...
+            </div>
+        }
+        else if (_instances.Count == 0)
+        {
+            <div class="p-3 text-muted">No instances found.
+                <a href="/instances/new">Add the first one.</a>
+            </div>
+        }
+        else
+        {
+            <table class="table table-hover table-sm mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th>Instance</th>
+                        <th>Environment</th>
+                        <th>Version / Edition</th>
+                        <th>Host OS</th>
+                        <th class="text-center">AG</th>
+                        <th class="text-center">Clustered</th>
+                        <th>Tags</th>
+                        <th>Status</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var inst in _instances)
+                    {
+                        <tr>
+                            <td>
+                                <a href="/instances/@inst.InstanceId" class="fw-semibold text-decoration-none">
+                                    @inst.FullName
+                                </a>
+                                @if (inst.Port != 1433)
+                                {
+                                    <span class="text-muted small ms-1">,@inst.Port</span>
+                                }
+                            </td>
+                            <td>
+                                <span class="badge-env" style="background-color:@inst.Environment.ColorHex">
+                                    @inst.Environment.Name
+                                </span>
+                            </td>
+                            <td>
+                                @if (inst.SqlVersion is not null)
+                                {
+                                    <span>SQL @inst.SqlVersion</span>
+                                }
+                                @if (inst.SqlEdition is not null)
+                                {
+                                    <span class="text-muted small ms-1">@inst.SqlEdition</span>
+                                }
+                            </td>
+                            <td class="text-muted small">@(inst.HostOperatingSystem ?? "—")</td>
+                            <td class="text-center">
+                                @if (inst.IsAlwaysOnEnabled)
+                                {
+                                    <i class="bi bi-check-circle-fill text-success"></i>
+                                }
+                                else
+                                {
+                                    <span class="text-muted">—</span>
+                                }
+                            </td>
+                            <td class="text-center">
+                                @if (inst.IsClustered)
+                                {
+                                    <i class="bi bi-check-circle-fill text-info"></i>
+                                }
+                                else
+                                {
+                                    <span class="text-muted">—</span>
+                                }
+                            </td>
+                            <td>
+                                @foreach (var it in inst.InstanceTags)
+                                {
+                                    <span class="badge me-1" style="background-color:@it.Tag.ColorHex">
+                                        @it.Tag.Name
+                                    </span>
+                                }
+                            </td>
+                            <td>
+                                @if (inst.IsActive)
+                                {
+                                    <span class="badge bg-success">Active</span>
+                                }
+                                else
+                                {
+                                    <span class="badge bg-secondary">Inactive</span>
+                                }
+                            </td>
+                            <td class="text-end">
+                                <a href="/instances/@inst.InstanceId/edit" class="btn btn-outline-secondary btn-sm me-1">
+                                    <i class="bi bi-pencil"></i>
+                                </a>
+                                <button class="btn btn-outline-danger btn-sm" @onclick="() => ConfirmDelete(inst)">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+    </div>
+</div>
+
+@if (_deleteTarget is not null)
+{
+    <div class="modal d-block" tabindex="-1" style="background:rgba(0,0,0,.4)">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Confirm Delete</h5>
+                    <button class="btn-close" @onclick="() => _deleteTarget = null"></button>
+                </div>
+                <div class="modal-body">
+                    Delete <strong>@_deleteTarget.FullName</strong>? This will also remove all associated databases and tags.
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-secondary" @onclick="() => _deleteTarget = null">Cancel</button>
+                    <button class="btn btn-danger" @onclick="DeleteAsync">Delete</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private List<SqlInstance> _instances = [];
+    private List<Environment> _environments = [];
+    private string _search = "";
+    private int _envFilter = 0;
+    private string _activeFilter = "true";
+    private bool _loading = true;
+    private SqlInstance? _deleteTarget;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _environments = await InstanceService.GetEnvironmentsAsync();
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        StateHasChanged();
+        bool? active = _activeFilter switch { "true" => true, "false" => false, _ => null };
+        _instances = await InstanceService.GetAllAsync(
+            string.IsNullOrWhiteSpace(_search) ? null : _search,
+            _envFilter == 0 ? null : _envFilter,
+            active);
+        _loading = false;
+    }
+
+    private void ConfirmDelete(SqlInstance inst) => _deleteTarget = inst;
+
+    private async Task DeleteAsync()
+    {
+        if (_deleteTarget is not null)
+        {
+            await InstanceService.DeleteAsync(_deleteTarget.InstanceId);
+            _deleteTarget = null;
+            await LoadAsync();
+        }
+    }
+}

--- a/src/SQLInventory/Pages/Tags/Index.razor
+++ b/src/SQLInventory/Pages/Tags/Index.razor
@@ -1,0 +1,109 @@
+@page "/tags"
+@inject TagService TagService
+
+<PageTitle>Tags - SQL Inventory</PageTitle>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h4 class="mb-0"><i class="bi bi-tags me-2"></i>Tags</h4>
+    <button class="btn btn-primary btn-sm" @onclick="StartAdd">
+        <i class="bi bi-plus-lg me-1"></i>Add Tag
+    </button>
+</div>
+
+@if (_loading)
+{
+    <div class="text-muted d-flex gap-2"><div class="spinner-border spinner-border-sm"></div> Loading...</div>
+}
+else
+{
+    <div class="row g-3">
+        @foreach (var tag in _tags)
+        {
+            <div class="col-md-3">
+                <div class="card shadow-sm">
+                    <div class="card-body d-flex justify-content-between align-items-center">
+                        <span class="badge fs-6" style="background-color:@tag.ColorHex">@tag.Name</span>
+                        <div class="d-flex gap-1">
+                            <button class="btn btn-outline-secondary btn-sm" @onclick="() => StartEdit(tag)">
+                                <i class="bi bi-pencil"></i>
+                            </button>
+                            <button class="btn btn-outline-danger btn-sm" @onclick="() => DeleteAsync(tag.TagId)">
+                                <i class="bi bi-trash"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        }
+        @if (_tags.Count == 0)
+        {
+            <div class="col-12 text-muted">No tags yet. Create one to categorize your instances.</div>
+        }
+    </div>
+}
+
+@if (_editing is not null)
+{
+    <div class="modal d-block" tabindex="-1" style="background:rgba(0,0,0,.4)">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">@(_editing.TagId == 0 ? "Add Tag" : "Edit Tag")</h5>
+                    <button class="btn-close" @onclick="() => _editing = null"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">Name <span class="text-danger">*</span></label>
+                        <input class="form-control" @bind="_editing.Name" />
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Color</label>
+                        <div class="d-flex gap-2 align-items-center">
+                            <input type="color" class="form-control form-control-color" @bind="_editing.ColorHex" />
+                            <span class="badge fs-6" style="background-color:@_editing.ColorHex">@_editing.Name</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-secondary" @onclick="() => _editing = null">Cancel</button>
+                    <button class="btn btn-primary" @onclick="SaveAsync">Save</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private List<Tag> _tags = [];
+    private bool _loading = true;
+    private Tag? _editing;
+
+    protected override async Task OnInitializedAsync() => await LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        _tags = await TagService.GetAllAsync();
+        _loading = false;
+    }
+
+    private void StartAdd() => _editing = new Tag { ColorHex = "#0d6efd" };
+    private void StartEdit(Tag tag) => _editing = new Tag { TagId = tag.TagId, Name = tag.Name, ColorHex = tag.ColorHex };
+
+    private async Task SaveAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_editing?.Name)) return;
+        if (_editing.TagId == 0)
+            await TagService.CreateAsync(_editing);
+        else
+            await TagService.UpdateAsync(_editing);
+        _editing = null;
+        await LoadAsync();
+    }
+
+    private async Task DeleteAsync(int id)
+    {
+        await TagService.DeleteAsync(id);
+        await LoadAsync();
+    }
+}

--- a/src/SQLInventory/Pages/_Host.cshtml
+++ b/src/SQLInventory/Pages/_Host.cshtml
@@ -1,0 +1,8 @@
+@page "/"
+@namespace SQLInventory.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    Layout = "_Layout";
+}
+
+<component type="typeof(SQLInventory.Components.App)" render-mode="ServerPrerendered" />

--- a/src/SQLInventory/Pages/_Layout.cshtml
+++ b/src/SQLInventory/Pages/_Layout.cshtml
@@ -1,0 +1,21 @@
+@using Microsoft.AspNetCore.Components.Web
+@namespace SQLInventory.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="~/" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
+</head>
+<body>
+    @RenderBody()
+    <script src="_framework/blazor.server.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/SQLInventory/Program.cs
+++ b/src/SQLInventory/Program.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using SQLInventory.Data;
+using SQLInventory.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(
+        builder.Configuration.GetConnectionString("DefaultConnection"),
+        sql => sql.CommandTimeout(60)));
+
+builder.Services.AddScoped<InstanceService>();
+builder.Services.AddScoped<DatabaseService>();
+builder.Services.AddScoped<AvailabilityGroupService>();
+builder.Services.AddScoped<TagService>();
+builder.Services.AddScoped<DiscoveryService>();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.UseAntiforgery();
+
+app.MapRazorComponents<SQLInventory.Components.App>()
+    .AddInteractiveServerRenderMode();
+
+app.Run();

--- a/src/SQLInventory/SQLInventory.csproj
+++ b/src/SQLInventory/SQLInventory.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>SQLInventory</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/SQLInventory/Services/AvailabilityGroupService.cs
+++ b/src/SQLInventory/Services/AvailabilityGroupService.cs
@@ -1,0 +1,63 @@
+using Microsoft.EntityFrameworkCore;
+using SQLInventory.Data;
+using SQLInventory.Data.Entities;
+
+namespace SQLInventory.Services;
+
+public class AvailabilityGroupService(AppDbContext db)
+{
+    public Task<List<AvailabilityGroup>> GetAllAsync() =>
+        db.AvailabilityGroups
+          .Include(ag => ag.PrimaryInstance).ThenInclude(i => i.Environment)
+          .Include(ag => ag.Replicas).ThenInclude(r => r.Instance)
+          .OrderBy(ag => ag.AgName)
+          .ToListAsync();
+
+    public Task<AvailabilityGroup?> GetByIdAsync(int id) =>
+        db.AvailabilityGroups
+          .Include(ag => ag.PrimaryInstance).ThenInclude(i => i.Environment)
+          .Include(ag => ag.Replicas).ThenInclude(r => r.Instance)
+          .FirstOrDefaultAsync(ag => ag.AgId == id);
+
+    public async Task<AvailabilityGroup> CreateAsync(AvailabilityGroup ag)
+    {
+        ag.CreatedUtc = DateTime.UtcNow;
+        ag.ModifiedUtc = DateTime.UtcNow;
+        db.AvailabilityGroups.Add(ag);
+        await db.SaveChangesAsync();
+        return ag;
+    }
+
+    public async Task UpdateAsync(AvailabilityGroup ag)
+    {
+        ag.ModifiedUtc = DateTime.UtcNow;
+        db.AvailabilityGroups.Update(ag);
+        await db.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var ag = await db.AvailabilityGroups.FindAsync(id);
+        if (ag is not null)
+        {
+            db.AvailabilityGroups.Remove(ag);
+            await db.SaveChangesAsync();
+        }
+    }
+
+    public async Task AddReplicaAsync(AgReplica replica)
+    {
+        db.AgReplicas.Add(replica);
+        await db.SaveChangesAsync();
+    }
+
+    public async Task RemoveReplicaAsync(int replicaId)
+    {
+        var replica = await db.AgReplicas.FindAsync(replicaId);
+        if (replica is not null)
+        {
+            db.AgReplicas.Remove(replica);
+            await db.SaveChangesAsync();
+        }
+    }
+}

--- a/src/SQLInventory/Services/DatabaseService.cs
+++ b/src/SQLInventory/Services/DatabaseService.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using SQLInventory.Data;
+using SQLInventory.Data.Entities;
+
+namespace SQLInventory.Services;
+
+public class DatabaseService(AppDbContext db)
+{
+    public Task<List<SqlDatabase>> GetAllAsync(int? instanceId = null)
+    {
+        var q = db.SqlDatabases.Include(d => d.Instance).AsQueryable();
+        if (instanceId.HasValue)
+            q = q.Where(d => d.InstanceId == instanceId.Value);
+        return q.OrderBy(d => d.Instance.ServerName).ThenBy(d => d.DatabaseName).ToListAsync();
+    }
+
+    public Task<SqlDatabase?> GetByIdAsync(int id) =>
+        db.SqlDatabases.Include(d => d.Instance).FirstOrDefaultAsync(d => d.DatabaseId == id);
+
+    public async Task<SqlDatabase> CreateAsync(SqlDatabase database)
+    {
+        database.CreatedUtc = DateTime.UtcNow;
+        database.ModifiedUtc = DateTime.UtcNow;
+        db.SqlDatabases.Add(database);
+        await db.SaveChangesAsync();
+        return database;
+    }
+
+    public async Task UpdateAsync(SqlDatabase database)
+    {
+        database.ModifiedUtc = DateTime.UtcNow;
+        db.SqlDatabases.Update(database);
+        await db.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var db2 = await db.SqlDatabases.FindAsync(id);
+        if (db2 is not null)
+        {
+            db.SqlDatabases.Remove(db2);
+            await db.SaveChangesAsync();
+        }
+    }
+}

--- a/src/SQLInventory/Services/DiscoveryService.cs
+++ b/src/SQLInventory/Services/DiscoveryService.cs
@@ -1,0 +1,325 @@
+using Microsoft.Data.SqlClient;
+using SQLInventory.Data.Entities;
+
+namespace SQLInventory.Services;
+
+public class DiscoveryResult
+{
+    public bool Success { get; set; }
+    public string? ErrorMessage { get; set; }
+    public SqlInstance? Instance { get; set; }
+    public List<SqlDatabase> Databases { get; set; } = [];
+    public List<DiscoveredAg> AvailabilityGroups { get; set; } = [];
+}
+
+public class DiscoveredAg
+{
+    public string AgName { get; set; } = "";
+    public string? ClusterType { get; set; }
+    public string? AutomatedBackupPreference { get; set; }
+    public List<DiscoveredReplica> Replicas { get; set; } = [];
+}
+
+public class DiscoveredReplica
+{
+    public string ReplicaServerName { get; set; } = "";
+    public string Role { get; set; } = "";
+    public string? AvailabilityMode { get; set; }
+    public string? FailoverMode { get; set; }
+    public string? SeedingMode { get; set; }
+}
+
+public class DiscoveryService(InstanceService instanceService, DatabaseService databaseService, AvailabilityGroupService agService)
+{
+    public async Task<DiscoveryResult> DiscoverAsync(string serverName, string? instanceName, int port,
+        string? username, string? password, int environmentId, CancellationToken ct = default)
+    {
+        var fullName = instanceName is not null ? $"{serverName}\\{instanceName}" : serverName;
+        var connTarget = port != 1433 ? $"{fullName},{port}" : fullName;
+
+        var builder = new SqlConnectionStringBuilder
+        {
+            DataSource = connTarget,
+            InitialCatalog = "master",
+            TrustServerCertificate = true,
+            ConnectTimeout = 15
+        };
+
+        if (!string.IsNullOrWhiteSpace(username))
+        {
+            builder.UserID = username;
+            builder.Password = password;
+            builder.IntegratedSecurity = false;
+        }
+        else
+        {
+            builder.IntegratedSecurity = true;
+        }
+
+        var result = new DiscoveryResult();
+
+        try
+        {
+            await using var conn = new SqlConnection(builder.ConnectionString);
+            await conn.OpenAsync(ct);
+
+            var instance = new SqlInstance
+            {
+                ServerName = serverName,
+                InstanceName = string.IsNullOrWhiteSpace(instanceName) ? null : instanceName,
+                Port = port,
+                EnvironmentId = environmentId,
+                LastDiscoveredUtc = DateTime.UtcNow
+            };
+
+            // ── Instance metadata ───────────────────────────────────────────
+            const string instanceSql = """
+                SELECT
+                    @@VERSION                                          AS FullVersion,
+                    CAST(SERVERPROPERTY('ProductVersion') AS NVARCHAR) AS Build,
+                    CAST(SERVERPROPERTY('Edition')        AS NVARCHAR) AS Edition,
+                    CAST(SERVERPROPERTY('IsClustered')    AS INT)      AS IsClustered,
+                    CAST(SERVERPROPERTY('IsHadrEnabled')  AS INT)      AS IsAlwaysOnEnabled,
+                    CAST(SERVERPROPERTY('ComputerNamePhysicalNetBIOS') AS NVARCHAR) AS HostName;
+                """;
+
+            await using (var cmd = new SqlCommand(instanceSql, conn))
+            await using (var rdr = await cmd.ExecuteReaderAsync(ct))
+            {
+                if (await rdr.ReadAsync(ct))
+                {
+                    var fullVer = rdr["FullVersion"]?.ToString() ?? "";
+                    instance.SqlBuild = rdr["Build"]?.ToString();
+                    instance.SqlEdition = rdr["Edition"]?.ToString();
+                    instance.IsClustered = Convert.ToInt32(rdr["IsClustered"]) == 1;
+                    instance.IsAlwaysOnEnabled = Convert.ToInt32(rdr["IsAlwaysOnEnabled"]) == 1;
+                    instance.HostOperatingSystem = rdr["HostName"]?.ToString();
+
+                    // Parse major version year from build (e.g., 15.x = 2019, 16.x = 2022)
+                    if (instance.SqlBuild is not null && instance.SqlBuild.Split('.') is [var major, ..])
+                    {
+                        instance.SqlVersion = major switch
+                        {
+                            "16" => "2022",
+                            "15" => "2019",
+                            "14" => "2017",
+                            "13" => "2016",
+                            "12" => "2014",
+                            "11" => "2012",
+                            _ => major
+                        };
+                    }
+                    _ = fullVer; // used for debugging if needed
+                }
+            }
+
+            // ── CPU / Memory ────────────────────────────────────────────────
+            const string sysSql = "SELECT cpu_count, physical_memory_kb / 1024 AS PhysicalMemoryMb FROM sys.dm_os_sys_info;";
+            await using (var cmd = new SqlCommand(sysSql, conn))
+            await using (var rdr = await cmd.ExecuteReaderAsync(ct))
+            {
+                if (await rdr.ReadAsync(ct))
+                {
+                    instance.CpuCount = rdr.GetInt32(rdr.GetOrdinal("cpu_count"));
+                }
+            }
+
+            // ── Max memory config ───────────────────────────────────────────
+            const string memSql = "SELECT CAST(value_in_use AS INT) AS MaxMemoryMb FROM sys.configurations WHERE name = 'max server memory (MB)';";
+            await using (var cmd = new SqlCommand(memSql, conn))
+            await using (var rdr = await cmd.ExecuteReaderAsync(ct))
+            {
+                if (await rdr.ReadAsync(ct))
+                    instance.MaxMemoryMb = rdr.GetInt32(0);
+            }
+
+            result.Instance = instance;
+
+            // ── Databases ───────────────────────────────────────────────────
+            const string dbSql = """
+                SELECT
+                    d.name,
+                    d.state_desc,
+                    d.recovery_model_desc,
+                    d.compatibility_level,
+                    d.collation_name,
+                    SUSER_SNAME(d.owner_sid) AS owner,
+                    d.create_date,
+                    CAST(SUM(mf.size) * 8.0 / 1024 AS DECIMAL(18,2)) AS SizeMb
+                FROM sys.databases d
+                JOIN sys.master_files mf ON d.database_id = mf.database_id
+                WHERE d.database_id > 4
+                GROUP BY d.name, d.state_desc, d.recovery_model_desc, d.compatibility_level,
+                         d.collation_name, d.owner_sid, d.create_date;
+                """;
+
+            await using (var cmd = new SqlCommand(dbSql, conn))
+            await using (var rdr = await cmd.ExecuteReaderAsync(ct))
+            {
+                while (await rdr.ReadAsync(ct))
+                {
+                    result.Databases.Add(new SqlDatabase
+                    {
+                        DatabaseName = rdr["name"].ToString()!,
+                        StateDesc = rdr["state_desc"]?.ToString(),
+                        RecoveryModel = rdr["recovery_model_desc"]?.ToString(),
+                        CompatibilityLevel = rdr["compatibility_level"] as int?,
+                        CollationName = rdr["collation_name"]?.ToString(),
+                        Owner = rdr["owner"]?.ToString(),
+                        SizeMb = rdr["SizeMb"] as decimal?
+                    });
+                }
+            }
+
+            // ── Last backup dates ───────────────────────────────────────────
+            const string backupSql = """
+                SELECT database_name, type, MAX(backup_finish_date) AS LastBackup
+                FROM msdb.dbo.backupset
+                WHERE database_name IN (SELECT name FROM sys.databases WHERE database_id > 4)
+                GROUP BY database_name, type;
+                """;
+
+            try
+            {
+                await using var cmd = new SqlCommand(backupSql, conn);
+                await using var rdr = await cmd.ExecuteReaderAsync(ct);
+                while (await rdr.ReadAsync(ct))
+                {
+                    var dbName = rdr["database_name"].ToString();
+                    var type = rdr["type"].ToString();
+                    var lastBackup = rdr["LastBackup"] as DateTime?;
+                    var match = result.Databases.FirstOrDefault(d => d.DatabaseName == dbName);
+                    if (match is null) continue;
+                    if (type == "D") match.LastFullBackupUtc = lastBackup;
+                    else if (type == "L") match.LastLogBackupUtc = lastBackup;
+                }
+            }
+            catch
+            {
+                // msdb may not be accessible; skip backup history
+            }
+
+            // ── Availability Groups ─────────────────────────────────────────
+            if (instance.IsAlwaysOnEnabled)
+            {
+                const string agSql = """
+                    SELECT
+                        ag.name                              AS AgName,
+                        ag.cluster_type_desc                 AS ClusterType,
+                        ag.automated_backup_preference_desc  AS BackupPref,
+                        ar.replica_server_name               AS ReplicaServer,
+                        ar.availability_mode_desc            AS AvailMode,
+                        ar.failover_mode_desc                AS FailoverMode,
+                        ar.seeding_mode_desc                 AS SeedingMode,
+                        ars.role_desc                        AS Role
+                    FROM sys.availability_groups ag
+                    JOIN sys.availability_replicas ar
+                        ON ag.group_id = ar.group_id
+                    JOIN sys.dm_hadr_availability_replica_states ars
+                        ON ar.replica_id = ars.replica_id;
+                    """;
+
+                try
+                {
+                    await using var cmd = new SqlCommand(agSql, conn);
+                    await using var rdr = await cmd.ExecuteReaderAsync(ct);
+                    while (await rdr.ReadAsync(ct))
+                    {
+                        var agName = rdr["AgName"].ToString()!;
+                        var ag = result.AvailabilityGroups.FirstOrDefault(a => a.AgName == agName);
+                        if (ag is null)
+                        {
+                            ag = new DiscoveredAg
+                            {
+                                AgName = agName,
+                                ClusterType = rdr["ClusterType"]?.ToString(),
+                                AutomatedBackupPreference = rdr["BackupPref"]?.ToString()
+                            };
+                            result.AvailabilityGroups.Add(ag);
+                        }
+                        ag.Replicas.Add(new DiscoveredReplica
+                        {
+                            ReplicaServerName = rdr["ReplicaServer"].ToString()!,
+                            Role = rdr["Role"].ToString()!,
+                            AvailabilityMode = rdr["AvailMode"]?.ToString(),
+                            FailoverMode = rdr["FailoverMode"]?.ToString(),
+                            SeedingMode = rdr["SeedingMode"]?.ToString()
+                        });
+                    }
+                }
+                catch
+                {
+                    // AG views may not be accessible on secondary; skip
+                }
+            }
+
+            result.Success = true;
+        }
+        catch (Exception ex)
+        {
+            result.Success = false;
+            result.ErrorMessage = ex.Message;
+        }
+
+        return result;
+    }
+
+    public async Task<SqlInstance> ImportAsync(DiscoveryResult result, int environmentId)
+    {
+        if (!result.Success || result.Instance is null)
+            throw new InvalidOperationException("Discovery did not succeed.");
+
+        var instance = result.Instance;
+
+        // Upsert instance
+        var existing = (await instanceService.GetAllAsync())
+            .FirstOrDefault(i =>
+                string.Equals(i.ServerName, instance.ServerName, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(i.InstanceName, instance.InstanceName, StringComparison.OrdinalIgnoreCase));
+
+        if (existing is null)
+        {
+            await instanceService.CreateAsync(instance);
+        }
+        else
+        {
+            existing.SqlVersion = instance.SqlVersion;
+            existing.SqlEdition = instance.SqlEdition;
+            existing.SqlBuild = instance.SqlBuild;
+            existing.HostOperatingSystem = instance.HostOperatingSystem;
+            existing.IsClustered = instance.IsClustered;
+            existing.IsAlwaysOnEnabled = instance.IsAlwaysOnEnabled;
+            existing.MaxMemoryMb = instance.MaxMemoryMb;
+            existing.CpuCount = instance.CpuCount;
+            existing.LastDiscoveredUtc = instance.LastDiscoveredUtc;
+            await instanceService.UpdateAsync(existing);
+            instance = existing;
+        }
+
+        // Upsert databases
+        var existingDbs = await databaseService.GetAllAsync(instance.InstanceId);
+        foreach (var db in result.Databases)
+        {
+            db.InstanceId = instance.InstanceId;
+            var existingDb = existingDbs.FirstOrDefault(d =>
+                string.Equals(d.DatabaseName, db.DatabaseName, StringComparison.OrdinalIgnoreCase));
+
+            if (existingDb is null)
+                await databaseService.CreateAsync(db);
+            else
+            {
+                existingDb.SizeMb = db.SizeMb;
+                existingDb.StateDesc = db.StateDesc;
+                existingDb.RecoveryModel = db.RecoveryModel;
+                existingDb.CompatibilityLevel = db.CompatibilityLevel;
+                existingDb.CollationName = db.CollationName;
+                existingDb.Owner = db.Owner;
+                existingDb.LastFullBackupUtc = db.LastFullBackupUtc;
+                existingDb.LastLogBackupUtc = db.LastLogBackupUtc;
+                await databaseService.UpdateAsync(existingDb);
+            }
+        }
+
+        return instance;
+    }
+}

--- a/src/SQLInventory/Services/InstanceService.cs
+++ b/src/SQLInventory/Services/InstanceService.cs
@@ -1,0 +1,105 @@
+using Microsoft.EntityFrameworkCore;
+using SQLInventory.Data;
+using SQLInventory.Data.Entities;
+using Environment = SQLInventory.Data.Entities.Environment;
+
+namespace SQLInventory.Services;
+
+public class InstanceService(AppDbContext db)
+{
+    public Task<List<SqlInstance>> GetAllAsync(string? search = null, int? environmentId = null, bool? isActive = null)
+    {
+        var q = db.SqlInstances
+            .Include(i => i.Environment)
+            .Include(i => i.InstanceTags).ThenInclude(it => it.Tag)
+            .AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(search))
+            q = q.Where(i => i.ServerName.Contains(search) ||
+                              (i.InstanceName != null && i.InstanceName.Contains(search)) ||
+                              (i.Notes != null && i.Notes.Contains(search)));
+
+        if (environmentId.HasValue)
+            q = q.Where(i => i.EnvironmentId == environmentId.Value);
+
+        if (isActive.HasValue)
+            q = q.Where(i => i.IsActive == isActive.Value);
+
+        return q.OrderBy(i => i.ServerName).ThenBy(i => i.InstanceName).ToListAsync();
+    }
+
+    public Task<SqlInstance?> GetByIdAsync(int id) =>
+        db.SqlInstances
+          .Include(i => i.Environment)
+          .Include(i => i.InstanceTags).ThenInclude(it => it.Tag)
+          .Include(i => i.Databases)
+          .Include(i => i.PrimaryAvailabilityGroups).ThenInclude(ag => ag.Replicas).ThenInclude(r => r.Instance)
+          .Include(i => i.AgReplicas).ThenInclude(r => r.AvailabilityGroup)
+          .FirstOrDefaultAsync(i => i.InstanceId == id);
+
+    public async Task<SqlInstance> CreateAsync(SqlInstance instance)
+    {
+        instance.CreatedUtc = DateTime.UtcNow;
+        instance.ModifiedUtc = DateTime.UtcNow;
+        db.SqlInstances.Add(instance);
+        await db.SaveChangesAsync();
+        return instance;
+    }
+
+    public async Task UpdateAsync(SqlInstance instance)
+    {
+        instance.ModifiedUtc = DateTime.UtcNow;
+        db.SqlInstances.Update(instance);
+        await db.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var instance = await db.SqlInstances.FindAsync(id);
+        if (instance is not null)
+        {
+            db.SqlInstances.Remove(instance);
+            await db.SaveChangesAsync();
+        }
+    }
+
+    public async Task SetTagsAsync(int instanceId, IEnumerable<int> tagIds)
+    {
+        var existing = await db.InstanceTags.Where(it => it.InstanceId == instanceId).ToListAsync();
+        db.InstanceTags.RemoveRange(existing);
+        foreach (var tagId in tagIds)
+            db.InstanceTags.Add(new InstanceTag { InstanceId = instanceId, TagId = tagId });
+        await db.SaveChangesAsync();
+    }
+
+    public Task<List<Environment>> GetEnvironmentsAsync() =>
+        db.Environments.OrderBy(e => e.Name).ToListAsync();
+
+    public async Task<DashboardStats> GetDashboardStatsAsync()
+    {
+        var instanceCount = await db.SqlInstances.CountAsync(i => i.IsActive);
+        var databaseCount = await db.SqlDatabases.CountAsync();
+        var agCount = await db.AvailabilityGroups.CountAsync();
+        var envBreakdown = await db.SqlInstances
+            .Include(i => i.Environment)
+            .Where(i => i.IsActive)
+            .GroupBy(i => new { i.Environment.Name, i.Environment.ColorHex })
+            .Select(g => new EnvironmentCount(g.Key.Name, g.Key.ColorHex, g.Count()))
+            .ToListAsync();
+        var recent = await db.SqlInstances
+            .Include(i => i.Environment)
+            .OrderByDescending(i => i.ModifiedUtc)
+            .Take(5)
+            .ToListAsync();
+
+        return new DashboardStats(instanceCount, databaseCount, agCount, envBreakdown, recent);
+    }
+}
+
+public record EnvironmentCount(string Name, string ColorHex, int Count);
+public record DashboardStats(
+    int ActiveInstances,
+    int TotalDatabases,
+    int AvailabilityGroups,
+    List<EnvironmentCount> ByEnvironment,
+    List<SqlInstance> RecentlyModified);

--- a/src/SQLInventory/Services/TagService.cs
+++ b/src/SQLInventory/Services/TagService.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+using SQLInventory.Data;
+using SQLInventory.Data.Entities;
+
+namespace SQLInventory.Services;
+
+public class TagService(AppDbContext db)
+{
+    public Task<List<Tag>> GetAllAsync() =>
+        db.Tags.OrderBy(t => t.Name).ToListAsync();
+
+    public Task<Tag?> GetByIdAsync(int id) =>
+        db.Tags.FindAsync(id).AsTask();
+
+    public async Task<Tag> CreateAsync(Tag tag)
+    {
+        db.Tags.Add(tag);
+        await db.SaveChangesAsync();
+        return tag;
+    }
+
+    public async Task UpdateAsync(Tag tag)
+    {
+        db.Tags.Update(tag);
+        await db.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var tag = await db.Tags.FindAsync(id);
+        if (tag is not null)
+        {
+            db.Tags.Remove(tag);
+            await db.SaveChangesAsync();
+        }
+    }
+}

--- a/src/SQLInventory/_Imports.razor
+++ b/src/SQLInventory/_Imports.razor
@@ -1,0 +1,10 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using SQLInventory
+@using SQLInventory.Data.Entities
+@using SQLInventory.Services
+@using Environment = SQLInventory.Data.Entities.Environment

--- a/src/SQLInventory/appsettings.Development.json
+++ b/src/SQLInventory/appsettings.Development.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=SQLInventory;Integrated Security=true;TrustServerCertificate=true;"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Information"
+    }
+  }
+}

--- a/src/SQLInventory/appsettings.json
+++ b/src/SQLInventory/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=YOUR_SERVER;Database=SQLInventory;Integrated Security=true;TrustServerCertificate=true;"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/SQLInventory/wwwroot/css/site.css
+++ b/src/SQLInventory/wwwroot/css/site.css
@@ -1,0 +1,55 @@
+html, body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+}
+
+.app-shell {
+    display: flex;
+    height: 100vh;
+    overflow: hidden;
+}
+
+.sidebar {
+    width: 240px;
+    min-height: 100vh;
+    background-color: #212529;
+    flex-shrink: 0;
+    overflow-y: auto;
+}
+
+.sidebar .nav-link:hover,
+.sidebar .nav-link.active {
+    background-color: rgba(255, 255, 255, 0.15);
+    border-radius: 0.375rem;
+}
+
+.main-content {
+    flex: 1;
+    overflow-y: auto;
+    background-color: #f8f9fa;
+}
+
+.stat-card {
+    border: none;
+    border-radius: 0.5rem;
+}
+
+.badge-env {
+    font-size: 0.75rem;
+    padding: 0.3em 0.6em;
+    border-radius: 0.375rem;
+    color: #fff;
+}
+
+.table-hover tbody tr:hover {
+    background-color: rgba(13, 110, 253, 0.05);
+}
+
+.valid.modified:not([type=checkbox]) {
+    outline: 1px solid #26b050;
+}
+
+.invalid.modified:not([type=checkbox]) {
+    outline: 1px solid red;
+}


### PR DESCRIPTION
Full-stack Blazor Server web app (.NET 8) for tracking an organization's
SQL Server estate — instances, databases, availability groups, tags, and
environments — with both manual CRUD and live auto-discovery.

## What's included

### Database (db/)
- schema.sql: Full T-SQL schema (7 tables, FKs, indexes, idempotent)
- seed.sql: 5 environments, sample tags, 3 instances, databases, and 1 AG

### Application (src/SQLInventory/)
- ASP.NET Core 8 Blazor Web App with Interactive Server rendering
- Entity Framework Core 8 (SQL Server provider)
- 7 entity models: Environment, SqlInstance, SqlDatabase,
  AvailabilityGroup, AgReplica, Tag, InstanceTag
- 5 services: InstanceService, DatabaseService, AvailabilityGroupService,
  TagService, DiscoveryService

### Pages
- Dashboard: summary cards (instances, databases, AGs) + environment
  breakdown + recently modified instances
- Instances: searchable/filterable grid, create/edit form, detail view
  with databases and AG topology
- Databases: filterable list across all instances
- Availability Groups: AG list with replica topology
- Tags: tag CRUD with colour picker
- Discovery: connect to a live SQL Server, preview its metadata
  (version, edition, databases, AGs), then import into inventory

https://claude.ai/code/session_01Rf33TyUAYk8cMD9YWS6FbJ